### PR TITLE
readable._construct compatible with lower versions of Node.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "js-sha256": "^0.9.0",
     "keccak256": "^1.0.6",
     "loglevel": "^1.9.1",
-    "secp256k1": "^5.0.0"
+    "secp256k1": "^5.0.0",
+    "semver": "^7.6.3"
   },
   "publishConfig": {
     "access": "public"

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -11,6 +11,8 @@ declare const _default: {
   dataHashOfSealedFile: any;
   signedDataHash: any;
   forwardSkey: any;
+  Unsealer: any;
+  SealedFileStream: any;
 };
 export const downloadJson: typeof _default.downloadJson;
 export const DataProvider: typeof _default.dataProvider;
@@ -24,4 +26,6 @@ export const ToString: typeof _default.ToString;
 export const dataHashOfSealedFile: typeof _default.dataHashOfSealedFile;
 export const signedDataHash: typeof _default.signedDataHash;
 export const forwardSkey: typeof _default.forwardSkey;
+export const Unsealer: typeof _default.Unsealer;
+export const SealedFileStream: typeof _default.SealedFileStream;
 export default _default;


### PR DESCRIPTION
创建SealedFileStream时，使用了`_construct`方法，但是，此方法，新增于 [nodejs@15.0.0](https://nodejs.cn/api/v20/stream.html#readable_constructcallback)。
[典枢](https://dianshudata.com)桌面应用，依赖 node@14.16.0。
因此，希望兼容低版本。
相关测试用例已通过。