### PR TITLE
Add browser crypto implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,55 +31,71 @@ yarn install
 yarn test
 ```
 
+#### 快速开始
+
+```js
+import { YPCCrypto } from "@yeez-tech/meta-encryptor";
+
+// YPCCrypto 是单例对象（Node / Browser / SSR 通用）
+// 不需要、也不能调用 ()
+const crypto = YPCCrypto;
+
+// 生成密钥对
+const sKey = crypto.generatePrivateKey();
+const pKey = crypto.generatePublicKeyFromPrivateKey(sKey);
+
+// 生成文件名和文件内容
+const fileName = crypto.generateFileNameFromPKey(pKey);
+const fileContent = crypto.generateFileContentFromSKey(sKey);
+
+// 解密消息（浏览器环境需要 await）
+await crypto.decryptMessage(sKey, encryptedMessage);
+```
+
 #### API
 
-##### crypto.generatePrivateKey
+##### YPCCrypto.generatePrivateKey
 
 生成私钥
 
 ```js
-import {crypto} from '@yeez-tech/meta-encryptor';
+import { YPCCrypto } from "@yeez-tech/meta-encryptor";
 
+const crypto = YPCCrypto;
 const sKey = crypto.generatePrivateKey();
-
-console.log('私钥=', sKey);
-const pKey = meta.crypto.generatePublicKeyFromPrivateKey(sKey);
-useStore().commit(ConfigMutationTypes.SET_ENCRYPTION_CONFIG, {
-    privateKey: sKey.toString('hex'),
-    publicKey: pKey.toString('hex')
-});
-const ypcName = meta.crypto.generateFileNameFromPKey(pKey);
-const ypcJson = meta.crypto.generateFileContentFromSKey(sKey);
 ```
 
-##### crypto.generatePublicKeyFromPrivateKey
+##### YPCCrypto.generatePublicKeyFromPrivateKey
 
 通过私钥生成公钥
 
 ```js
-import {crypto} from '@yeez-tech/meta-encryptor';
+import { YPCCrypto } from "@yeez-tech/meta-encryptor";
+
+const crypto = YPCCrypto;
 const pKey = crypto.generatePublicKeyFromPrivateKey(sKey);
-console.log('公钥钥=', pKey);
 ```
 
-##### crypto.generateFileNameFromPKey
+##### YPCCrypto.generateFileNameFromPKey
 
 通过公钥生成文件名
 
 ```js
-import {crypto} from '@yeez-tech/meta-encryptor';
-const ypcName = crypto.generateFileNameFromPKey(pKey);
-console.log('文件名=', ypcName);
+import { YPCCrypto } from "@yeez-tech/meta-encryptor";
+
+const crypto = YPCCrypto;
+const fileName = crypto.generateFileNameFromPKey(pKey);
 ```
 
-##### crypto.generateFileContentFromSKey
+##### YPCCrypto.generateFileContentFromSKey
 
 通过私钥获取密钥文件内容
 
 ```js
-import {crypto} from '@yeez-tech/meta-encryptor';
-const ypcJson = crypto.generateFileContentFromSKey(sKey);
-console.log('文件内容=', ypcJson);
+import { YPCCrypto } from "@yeez-tech/meta-encryptor";
+
+const crypto = YPCCrypto;
+const fileContent = crypto.generateFileContentFromSKey(sKey);
 ```
 
 ##### Sealer
@@ -103,7 +119,7 @@ rs.pipe(csv())
 Unsealer 用来解密流，并且将结果输出到流.
 
 ```js
-import {Sealer, Unsealer, SealedFileStream} from '@yeez-tech/meta-encryptor';
+import { Sealer, Unsealer, SealedFileStream } from "@yeez-tech/meta-encryptor";
 
 /*
 let src = "./tsconfig.json"
@@ -119,13 +135,13 @@ await new Promise(resolve=>{
 });
 */
 
-let unsealer = new Unsealer({keyPair: key_pair});
+let unsealer = new Unsealer({ keyPair: key_pair });
 let rrs = new SealedFileStream(dst);
-let wws = fs.createWriteStream(src + '.new');
+let wws = fs.createWriteStream(src + ".new");
 
 rrs.pipe(unsealer).pipe(wws);
 await new Promise((resolve) => {
-    wws.on('finish', () => resolve());
+  wws.on("finish", () => resolve());
 });
 ```
 
@@ -134,46 +150,53 @@ await new Promise((resolve) => {
 用于判断一个文件是否为一个有效的封装文件，如果为真，返回`true`，否则，返回`false`。
 
 ```js
-import {isSealedFile} from '@yeez-tech/meta-encryptor';
+import { isSealedFile } from "@yeez-tech/meta-encryptor";
 
 let r = isSealedFile(path);
 ```
 
-#### 浏览器端 Unsealer (实验性)
+#### 浏览器环境支持
 
-为了在纯浏览器环境中直接解密后端通过 HTTP 以二进制流提供的加密文件，本仓库提供了实验性实现：`src/browser/UnsealerBrowser.js` 与 `src/browser/ypccrypto.browser.js`。它通过 `fetch` 的 `ReadableStream` 增量读取加密文件，对照 Node 版 `Unsealer` 的协议解析 header 和每个 item 的长度前缀，调用浏览器版 `decryptMessage` 还原批次，再拼接为明文。
+本库同时支持 Node.js 和浏览器环境，使用方法完全一致。
 
-示例页面：`example/browser/index.html`。
-
-使用要点：
-1. 后端需提供已使用 Node 版 `Sealer` 生成的加密文件（格式：header | blocks(items with size prefix) | blockMeta | headerMeta）。当前浏览器版仍处于验证阶段，可能不支持全部边界情况。
-2. 在页面输入加密文件 URL 与私钥（hex）。公钥从加密文件的每段中动态获取。
-3. 点击“开始解密”后实时显示进度，完成后可下载合并后的明文。
-
-导入方式 (通过打包器或原始源码)：
 ```js
-import { UnsealerBrowser, unsealStream } from '@yeez-tech/meta-encryptor/dist/browser';
-// 或直接引用源码路径: import { unsealStream } from '.../src/browser/UnsealerBrowser.js'
+import { YPCCrypto } from '@yeez-tech/meta-encryptor'
+
+// YPCCrypto 是单例对象（Node / Browser / SSR 通用）
+// 不需要、也不能调用 ()
+const crypto = YPCCrypto
+
+await crypto.decryptMessage(...)
 ```
 
-核心 API：
+**注意**：
+
+- 库会自动检测运行环境并使用对应的实现（Node.js 或浏览器）
+- 由于 Web Crypto API 的限制，浏览器环境中部分方法（如 `decryptMessage`、`_encryptMessage` 等）是异步的，需要使用 `await` 调用
+
+##### 浏览器端下载功能
+
+在浏览器环境中，可以使用 `downloadUnsealed` 直接下载并解密文件：
+
 ```js
-await unsealStream(fetchResponse, {
-  privateKeyHex: 'YOUR_PRIVATE_KEY_HEX',
-  onChunk: (plaintextUint8) => { /* 每个数据块 */ },
-  progressHandler: (totalItems, processedItems, readBytes, writeBytes) => {}
+import { downloadUnsealed } from "@yeez-tech/meta-encryptor";
+
+await downloadUnsealed({
+  url: "https://example.com/encrypted file",
+  privateKeyHex: "YOUR_PRIVATE_KEY_HEX",
+  filename: "decrypted-file.txt",
+  progressHandler: (totalItems, processedItems, readBytes, writeBytes) => {
+    console.log(`Progress: ${processedItems}/${totalItems}`);
+  },
 });
 ```
-
-注意：浏览器版实现中 AES-CMAC 与 ECDH 派生流程是通过纯 JS 复刻，尚未经过完整安全审计，不建议在生产环境直接替换 Node 端实现。若需要生产支持，应将 Node 端逻辑通过打包工具（Rollup/Webpack）与适配层（例如 polyfill `crypto`）严格对齐后再使用。
-
 
 ##### sealedFileVersion
 
 返回封装文件的版本号。
 
 ```js
-import {sealedFileVersion} from '@yeez-tech/meta-encryptor';
+import { sealedFileVersion } from "@yeez-tech/meta-encryptor";
 
 let r = sealedFileVersion(path);
 ```
@@ -183,7 +206,7 @@ let r = sealedFileVersion(path);
 返回封装文件对应的原始数据的 hash。注意，该函数直接读取的是记录在文件头的 hash，如果文件被篡改，该函数有可能返回错误的 hash，因此，如果有可能，应该在解密之后，对 hash 进行校验。
 
 ```js
-import {dataHashOfSealedFile} from '@yeez-tech/meta-encryptor';
+import { dataHashOfSealedFile } from "@yeez-tech/meta-encryptor";
 
 let r = dataHashOfSealedFile(path);
 ```
@@ -193,7 +216,7 @@ let r = dataHashOfSealedFile(path);
 对数据 hash 进行签名。
 
 ```js
-import {signedDataHash} from '@yeez-tech/meta-encryptor';
+import { signedDataHash } from "@yeez-tech/meta-encryptor";
 
 //keyPair应该是{'private-key':'hex string of private key',
 //dataHash应该是一个Buffer，长度为32字节
@@ -205,7 +228,7 @@ let r = signedDataHash(keyPair, dataHash);
 生成转发枢私钥的信息。
 
 ```js
-import {forwardSkey} from '@yeez-tech/meta-encryptor';
+import { forwardSkey } from "@yeez-tech/meta-encryptor";
 
 //keyPair应该是{'private-key':'hex string of private key',
 //dianPKey应该是一个Buffer，包含了典公钥，
@@ -231,10 +254,10 @@ meta-encryptor 提供了支持断点续传的可恢复流功能，主要包含�
 用于支持断点续传的读取流，可以从指定位置恢复读取。
 
 ```js
-import {RecoverableReadStream} from '@yeez-tech/meta-encryptor';
+import { RecoverableReadStream } from "@yeez-tech/meta-encryptor";
 
-const context = new PipelineContextInFile('context.dat');
-const readStream = new RecoverableReadStream('input.file', context);
+const context = new PipelineContextInFile("context.dat");
+const readStream = new RecoverableReadStream("input.file", context);
 
 readStream.pipe(someWriteStream);
 ```
@@ -244,10 +267,10 @@ readStream.pipe(someWriteStream);
 用于支持断点续传的写入流，可以从指定位置恢复写入。
 
 ```js
-import {RecoverableWriteStream} from '@yeez-tech/meta-encryptor';
+import { RecoverableWriteStream } from "@yeez-tech/meta-encryptor";
 
-const context = new PipelineContextInFile('context.dat');
-const writeStream = new RecoverableWriteStream('output.file', context);
+const context = new PipelineContextInFile("context.dat");
+const writeStream = new RecoverableWriteStream("output.file", context);
 
 someReadStream.pipe(writeStream);
 ```
@@ -257,16 +280,16 @@ someReadStream.pipe(writeStream);
 用于管理断点续传过程中的上下文信息的基类。
 
 ```js
-import {PipelineContext} from '@yeez-tech/meta-encryptor';
+import { PipelineContext } from "@yeez-tech/meta-encryptor";
 
 class MyContext extends PipelineContext {
-    saveContext() {
-        // 实现保存上下文的逻辑
-    }
+  saveContext() {
+    // 实现保存上下文的逻辑
+  }
 
-    loadContext() {
-        // 实现加载上下文的逻辑
-    }
+  loadContext() {
+    // 实现加载上下文的逻辑
+  }
 }
 ```
 
@@ -275,9 +298,9 @@ class MyContext extends PipelineContext {
 基于文件存储的上下文管理实现，支持二进制数据。
 
 ```js
-import {PipelineContextInFile} from '@yeez-tech/meta-encryptor';
+import { PipelineContextInFile } from "@yeez-tech/meta-encryptor";
 
-const context = new PipelineContextInFile('context.dat');
+const context = new PipelineContextInFile("context.dat");
 
 // 保存上下文
 await context.saveContext();
@@ -289,21 +312,25 @@ await context.loadContext();
 使用示例：
 
 ```js
-import {RecoverableReadStream, RecoverableWriteStream, PipelineContextInFile} from '@yeez-tech/meta-encryptor';
+import {
+  RecoverableReadStream,
+  RecoverableWriteStream,
+  PipelineContextInFile,
+} from "@yeez-tech/meta-encryptor";
 
 // 创建上下文管理器
-const context = new PipelineContextInFile('transfer.context');
+const context = new PipelineContextInFile("transfer.context");
 
 // 创建可恢复的读写流
-const readStream = new RecoverableReadStream('source.file', context);
-const writeStream = new RecoverableWriteStream('target.file', context);
+const readStream = new RecoverableReadStream("source.file", context);
+const writeStream = new RecoverableWriteStream("target.file", context);
 
 // 处理传输
 readStream.pipe(writeStream);
 
 // 如果传输中断，可以使用相同的上下文重新创建流来继续传输
-const resumeReadStream = new RecoverableReadStream('source.file', context);
-const resumeWriteStream = new RecoverableWriteStream('target.file', context);
+const resumeReadStream = new RecoverableReadStream("source.file", context);
+const resumeWriteStream = new RecoverableWriteStream("target.file", context);
 resumeReadStream.pipe(resumeWriteStream);
 ```
 
@@ -315,24 +342,24 @@ meta-encryptor 支持将可恢复流与 Unsealer 结合使用，实现加密文�
 
 ```js
 import {
-    RecoverableReadStream,
-    RecoverableWriteStream,
-    PipelineContextInFile,
-    Unsealer
-} from '@yeez-tech/meta-encryptor';
+  RecoverableReadStream,
+  RecoverableWriteStream,
+  PipelineContextInFile,
+  Unsealer,
+} from "@yeez-tech/meta-encryptor";
 
 // 创建上下文管理器
-const context = new PipelineContextInFile('context.dat');
+const context = new PipelineContextInFile("context.dat");
 await context.loadContext();
 
 // 创建解密管道
 const readStream = new RecoverableReadStream(encryptedFile, context);
 const unsealer = new Unsealer({
-    keyPair,
-    context,
-    progressHandler: (totalItem, readItem, bytes, writeBytes) => {
-        console.log(`Progress: ${(bytes / (1024 * 1024)).toFixed(2)}MB`);
-    }
+  keyPair,
+  context,
+  progressHandler: (totalItem, readItem, bytes, writeBytes) => {
+    console.log(`Progress: ${(bytes / (1024 * 1024)).toFixed(2)}MB`);
+  },
 });
 const writeStream = new RecoverableWriteStream(decryptedFile, context);
 

--- a/download-unseal-sw.js
+++ b/download-unseal-sw.js
@@ -1,0 +1,126 @@
+// Service Worker for streaming decrypted data to a native download
+// Protocol:
+// - Page posts message { type: 'DOWNLOAD_PORT', id, name, size, path } with a MessagePort
+// - SW replies on that port with { type: 'ready' }
+// - Page navigates to `${path}?id=${id}` to trigger download
+// - Page sends { type: 'chunk', data: Uint8Array } and finally { type: 'end' } via the port
+// - SW responds to the fetch with a ReadableStream that relays the chunks
+
+/* global self */
+
+const downloads = new Map(); // id -> { port, name, size, path, buffer, controller, ended }
+
+function safeName(name) {
+	try {
+		const n = (name || 'download.bin').toString();
+		// Very simple sanitization
+		return n.replace(/[\r\n\\"']/g, '_');
+	} catch {
+		return 'download.bin';
+	}
+}
+
+self.addEventListener('install', (event) => {
+	self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+	event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('message', (event) => {
+	const data = event.data || {};
+	if (data && data.type === 'DOWNLOAD_PORT') {
+		const id = data.id;
+		const port = event.ports && event.ports[0];
+		const name = data.name || 'download.bin';
+		const size = data.size;
+		const path = data.path || '/__download_and_unseal__';
+		if (!id || !port || !path) return;
+
+		const entry = {
+			port,
+			name: safeName(name),
+			size: typeof size === 'number' && isFinite(size) ? size : undefined,
+			path,
+			buffer: [],
+			controller: null,
+			ended: false,
+		};
+
+		// Buffer incoming data until a fetch attaches a stream controller
+		port.onmessage = (ev) => {
+			const msg = ev.data || {};
+			if (msg.type === 'chunk') {
+				const u8 = msg.data;
+				if (entry.controller) {
+					try { entry.controller.enqueue(u8); } catch {}
+				} else {
+					entry.buffer.push(u8);
+				}
+			} else if (msg.type === 'end') {
+				entry.ended = true;
+				if (entry.controller) {
+					try { entry.controller.close(); } catch {}
+				}
+			} else if (msg.type === 'cancel') {
+				try { entry.controller?.error?.(new Error('cancelled')); } catch {}
+				downloads.delete(id);
+			}
+		};
+
+		downloads.set(id, entry);
+		try { port.postMessage({ type: 'ready' }); } catch {}
+	}
+});
+
+self.addEventListener('fetch', (event) => {
+	const url = new URL(event.request.url);
+	const id = url.searchParams.get('id');
+	if (!id) return; // Not our request
+
+	const entry = downloads.get(id);
+	if (!entry) return; // Unknown id
+
+	// Ensure path matches to avoid hijacking arbitrary paths
+	if (url.pathname !== entry.path) {
+		// Not the exact path, ignore
+		return;
+	}
+
+	event.respondWith((async () => {
+		// Build a streaming response
+		const headers = new Headers({
+			'Content-Type': 'application/octet-stream',
+			'Content-Disposition': `attachment; filename="${entry.name}"`,
+			'Cache-Control': 'no-store',
+		});
+		if (typeof entry.size === 'number') {
+			headers.set('Content-Length', String(entry.size));
+		}
+
+		const stream = new ReadableStream({
+			start(controller) {
+				entry.controller = controller;
+				// Flush buffered chunks
+				if (entry.buffer && entry.buffer.length) {
+					try { for (const chunk of entry.buffer) controller.enqueue(chunk); } catch {}
+					entry.buffer = [];
+				}
+				if (entry.ended) {
+					try { controller.close(); } catch {}
+					downloads.delete(id);
+				}
+			},
+			cancel() {
+				try { entry.port?.postMessage?.({ type: 'cancel' }); } catch {}
+				downloads.delete(id);
+			},
+		});
+
+		// Clean up when stream closes later
+		const response = new Response(stream, { status: 200, headers });
+		return response;
+	})());
+});
+

--- a/example/browser/index.html
+++ b/example/browser/index.html
@@ -51,6 +51,7 @@
     <button id="loadKeys">读取本地 keys.json</button>
     <button id="streamSaveBtn">边解密边保存</button>
     <button id="cleanBtn">清除临时文件</button>
+    <button id="chooseFileBtn">选择解密文件</button>
   </div>
 </fieldset>
 
@@ -94,6 +95,16 @@ const readBytesSpan = document.getElementById('readBytes');
 const writeBytesSpan = document.getElementById('writeBytes');
 
 let outputBuffers = [];
+
+// Hidden file input fallback for browsers that don't support showOpenFilePicker or when the user aborts it
+const hiddenFileInput = document.createElement('input');
+hiddenFileInput.type = 'file';
+hiddenFileInput.accept = '.bin,application/octet-stream';
+hiddenFileInput.style.display = 'none';
+document.body.appendChild(hiddenFileInput);
+
+const chooseFileBtn = document.getElementById('chooseFileBtn');
+chooseFileBtn.addEventListener('click', ()=> hiddenFileInput.click());
 
 async function withFileWriter(defaultName='unsealed.bin'){ 
   // Prefer File System Access API when available
@@ -210,24 +221,33 @@ verifyBtn.addEventListener('click', async ()=>{
     const plainBuf = new Uint8Array(await plainResp.arrayBuffer());
     log(`原始明文已获取：${plainBuf.length} 字节`);
 
-    // 读取刚才保存的解密文件：让用户手动选择本地文件来比对
-    let fileHandle;
-    if(window.showOpenFilePicker){
-      const [h] = await window.showOpenFilePicker({ types:[{description:'Binary', accept:{'application/octet-stream':['.bin']}}] });
-      fileHandle = h;
-      const f = await fileHandle.getFile();
-      const decBuf = new Uint8Array(await f.arrayBuffer());
-      log(`解密文件已选择：${decBuf.length} 字节，开始比对...`);
-      const equal = (a,b)=>{
-        if(a.length!==b.length) return false;
-        for(let i=0;i<a.length;i++){ if(a[i]!==b[i]) return false; }
-        return true;
-      };
-      const ok = equal(plainBuf, decBuf);
-      log(ok ? '比对一致 ✅' : '比对不一致 ❌');
-    } else {
-      log('当前浏览器不支持本地文件选择 API，请手动用其它工具比对。');
+    // 读取刚才保存的解密文件：优先使用 showOpenFilePicker，用户取消后降级到隐藏 file input
+    let decBuf = null;
+    try{
+      if(window.showOpenFilePicker){
+        const [h] = await window.showOpenFilePicker({ types:[{description:'Binary', accept:{'application/octet-stream':['.bin']}}] });
+        const f = await h.getFile();
+        decBuf = new Uint8Array(await f.arrayBuffer());
+      }
+    }catch(e){
+      // user aborted native picker or not allowed; fallback to hidden file input
+      log('本地打开被取消或不支持，使用页面文件选择作为后备');
+      decBuf = await new Promise((resolve, reject)=>{
+        hiddenFileInput.onchange = async ()=>{
+          try{ const f = hiddenFileInput.files[0]; if(!f) return reject(new Error('未选择文件')); const arr = new Uint8Array(await f.arrayBuffer()); resolve(arr); }catch(err){ reject(err); }
+        };
+        hiddenFileInput.click();
+      });
     }
+    if(!decBuf){ log('未能获取解密文件进行比对'); return; }
+    log(`解密文件已选择：${decBuf.length} 字节，开始比对...`);
+    const equal = (a,b)=>{
+      if(a.length!==b.length) return false;
+      for(let i=0;i<a.length;i++){ if(a[i]!==b[i]) return false; }
+      return true;
+    };
+    const ok = equal(plainBuf, decBuf);
+    log(ok ? '比对一致 ✅' : '比对不一致 ❌');
   }catch(e){
     log('检查失败: '+e.message);
   }

--- a/example/browser/index.html
+++ b/example/browser/index.html
@@ -1,0 +1,266 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <title>Browser Unsealer 示例</title>
+  <style>
+    body{font-family:system-ui,Arial,sans-serif;margin:2rem;max-width:900px;}
+    fieldset{margin:1rem 0;padding:1rem;border:1px solid #ccc;}
+    label{display:inline-block;min-width:140px;font-weight:600;}
+    input[type=text]{width:420px;}
+    #log{background:#111;color:#0f0;font-size:.8rem;height:160px;overflow:auto;padding:.75rem;white-space:pre-wrap;}
+    button{margin:.4rem .7rem .4rem 0;padding:.5rem 1rem;}
+  </style>
+  <script type="importmap">
+  {
+    "imports": {
+      "bytebuffer": "/src/browser/bytebuffer.browser.js",
+      "buffer": "https://esm.sh/buffer@6.0.3?target=es2020",
+      "keccak256": "https://esm.sh/keccak256@1.0.6?target=es2020",
+      "aes-js": "https://esm.sh/aes-js@3.1.2?target=es2020",
+      "@noble/secp256k1": "https://esm.sh/@noble/secp256k1@2.1.0?target=es2020"
+    }
+  }
+  </script>
+</head>
+<body>
+<h1>在浏览器中使用 Unsealer 解密流</h1>
+<p>你可以一键生成样本（自动生成 stream.bin 与 keys.json 并预填私钥），或者手动填写 URL 和私钥进行解密。</p>
+
+<fieldset>
+  <legend>输入</legend>
+  <div>
+    <label for="fileUrl">加密文件 URL</label>
+    <input id="fileUrl" type="text" placeholder="例如 https://example.com/encrypted.bin" />
+  </div>
+  <div>
+    <label for="privKey">私钥 (hex)</label>
+    <input id="privKey" type="text" placeholder="64字节十六进制" />
+  </div>
+  <div>
+    <label for="sizeSel">生成大小</label>
+    <select id="sizeSel">
+      <option value="1048576" selected>1 MB</option>
+      <option value="104857600">100 MB</option>
+      <option value="1073741824">1 GB</option>
+    </select>
+    <button id="verifyBtn">检查解密结果</button>
+  </div>
+  <div>
+    <button id="genAndRun">一键生成并解密</button>
+    <button id="loadKeys">读取本地 keys.json</button>
+    <button id="streamSaveBtn">边解密边保存</button>
+    <button id="cleanBtn">清除临时文件</button>
+  </div>
+</fieldset>
+
+<fieldset>
+  <legend>进度</legend>
+  <div>总条目: <span id="totalItems">?</span></div>
+  <div>已处理条目: <span id="processedItems">0</span></div>
+  <div>已读字节: <span id="readBytes">0</span></div>
+  <div>写出字节: <span id="writeBytes">0</span></div>
+</fieldset>
+
+<h3>日志</h3>
+<div id="log"></div>
+
+<script type="module">
+// Ensure Node.js Buffer APIs exist in the browser before loading modules that depend on it
+import { Buffer as BufferPolyfill } from 'buffer';
+if (!window.Buffer) {
+  window.Buffer = BufferPolyfill;
+}
+
+// Load Unsealer after Buffer is available
+const { unsealStream } = await import('../../src/browser/UnsealerBrowser.js');
+
+const logDiv = document.getElementById('log');
+function log(m){const t=new Date().toISOString();logDiv.textContent += `[${t}] ${m}\n`;logDiv.scrollTop=logDiv.scrollHeight;}
+window.addEventListener('error', (e)=>{ log('页面错误: '+ (e?.message||e)); });
+window.addEventListener('unhandledrejection', (e)=>{ log('未处理的Promise拒绝: '+ (e?.reason?.message||e?.reason||e)); });
+
+const streamSaveBtn = document.getElementById('streamSaveBtn');
+const genAndRunBtn = document.getElementById('genAndRun');
+const loadKeysBtn = document.getElementById('loadKeys');
+const cleanBtn = document.getElementById('cleanBtn');
+const verifyBtn = document.getElementById('verifyBtn');
+const sizeSel = document.getElementById('sizeSel');
+const fileUrlInput = document.getElementById('fileUrl');
+const privKeyInput = document.getElementById('privKey');
+const totalItemsSpan = document.getElementById('totalItems');
+const processedItemsSpan = document.getElementById('processedItems');
+const readBytesSpan = document.getElementById('readBytes');
+const writeBytesSpan = document.getElementById('writeBytes');
+
+let outputBuffers = [];
+
+async function withFileWriter(defaultName='unsealed.bin'){ 
+  // Prefer File System Access API when available
+  if(window.showSaveFilePicker){
+    const handle = await window.showSaveFilePicker({ suggestedName: defaultName, types:[{description:'Binary', accept:{'application/octet-stream':['.bin']}}] });
+    const writable = await handle.createWritable();
+    return {
+      async write(u8){ await writable.write(u8); },
+      async close(){ await writable.close(); }
+    };
+  }
+  // Fallback: accumulate to blob and trigger download at end
+  const chunks = [];
+  return {
+    async write(u8){ chunks.push(new Uint8Array(u8)); },
+    async close(){
+      const total = chunks.reduce((a,b)=>a+b.length,0);
+      const merged = new Uint8Array(total); let o=0; for(const c of chunks){ merged.set(c,o); o+=c.length; }
+      const blob = new Blob([merged]);
+      const a = document.createElement('a');
+      a.href = URL.createObjectURL(blob);
+      a.download = defaultName;
+      a.click();
+    }
+  };
+}
+
+async function autoPrefillKeys(){
+  try{
+    const base = location.origin;
+    const r = await fetch(`${base}/example/browser/keys.json`, {cache:'no-store'});
+    if(r.ok){
+      const j = await r.json();
+      if(j?.private_key){ privKeyInput.value = j.private_key; }
+      if(!fileUrlInput.value){ fileUrlInput.value = `${base}/example/browser/stream.bin`; }
+    }
+  }catch(e){ /* ignore */ }
+}
+
+window.addEventListener('DOMContentLoaded', autoPrefillKeys);
+
+// 快速自检：提示当前 origin
+log('页面已加载，origin='+ location.origin);
+
+streamSaveBtn.addEventListener('click', async ()=>{
+  outputBuffers = [];
+  const url = fileUrlInput.value.trim();
+  const priv = privKeyInput.value.trim();
+  if(!url || !priv){log('请填写 URL 和 私钥');return;}
+  log('开始获取加密文件流...');
+  try{
+  const resp = await fetch(url, { cache: 'no-store' });
+    if(!resp.ok) throw new Error('HTTP 状态: '+resp.status);
+    log('已连接，开始解密并写入文件...');
+    const writer = await withFileWriter('unsealed.bin');
+    await unsealStream(resp, {
+      privateKeyHex: priv,
+      onChunk: async (plain)=>{
+        outputBuffers.push(plain);
+        try{ log(`收到明文块: ${plain?.length||0} 字节`); }catch(e){}
+        await writer.write(plain);
+      },
+      progressHandler: (total, processed, readBytes, writeBytes)=>{
+        totalItemsSpan.textContent = total;
+        processedItemsSpan.textContent = processed;
+        readBytesSpan.textContent = readBytes;
+        writeBytesSpan.textContent = writeBytes;
+      }
+    });
+    // 统计总明文字节
+    const totalLen = outputBuffers.reduce((acc,b)=> acc + (b?.length||0),0);
+    log(`解密结束并写入完成，总输出块: ${outputBuffers.length}，总明文字节: ${totalLen}`);
+    if(totalLen > 0){
+      try{
+        const merged = new Uint8Array(totalLen);
+        let o=0; for(const b of outputBuffers){ merged.set(b, o); o+=b.length; }
+        const preview = new TextDecoder().decode(merged.slice(0, 256));
+        log('明文预览(前256字节 as UTF-8):');
+        log(preview.replace(/\n/g,'\\n'));
+      }catch(e){ /* ignore preview errors */ }
+    }
+    await writer.close();
+  }catch(e){
+    log('解密失败: '+e.message);
+  }
+});
+
+genAndRunBtn.addEventListener('click', async ()=>{
+  const base = location.origin;
+  try{
+    genAndRunBtn.disabled = true; streamSaveBtn.disabled = true;
+  const size = Number(sizeSel.value || (1024*1024*1024));
+  const r = await fetch(`${base}/api/gen?size=${size}`);
+    const j = await r.json();
+    if(!j.ok){ throw new Error(j.message || '生成失败'); }
+    // 预填并立即解密
+    privKeyInput.value = j.keys.private_key;
+    fileUrlInput.value = j.files.stream;
+    await (async ()=>{ streamSaveBtn.click(); })();
+  }catch(e){
+    log('生成或预填失败: '+e.message);
+  } finally {
+    genAndRunBtn.disabled = false; streamSaveBtn.disabled = false;
+  }
+});
+verifyBtn.addEventListener('click', async ()=>{
+  try{
+    const size = Number(sizeSel.value || 0);
+    if(!size){ log('请选择或输入正确的大小'); return; }
+    // 下载原始明文（按固定生成逻辑）
+    const base = location.origin;
+    const plainResp = await fetch(`${base}/api/plain?size=${size}`, {cache:'no-store'});
+    if(!plainResp.ok) throw new Error('下载原始明文失败: '+plainResp.status);
+    const plainBuf = new Uint8Array(await plainResp.arrayBuffer());
+    log(`原始明文已获取：${plainBuf.length} 字节`);
+
+    // 读取刚才保存的解密文件：让用户手动选择本地文件来比对
+    let fileHandle;
+    if(window.showOpenFilePicker){
+      const [h] = await window.showOpenFilePicker({ types:[{description:'Binary', accept:{'application/octet-stream':['.bin']}}] });
+      fileHandle = h;
+      const f = await fileHandle.getFile();
+      const decBuf = new Uint8Array(await f.arrayBuffer());
+      log(`解密文件已选择：${decBuf.length} 字节，开始比对...`);
+      const equal = (a,b)=>{
+        if(a.length!==b.length) return false;
+        for(let i=0;i<a.length;i++){ if(a[i]!==b[i]) return false; }
+        return true;
+      };
+      const ok = equal(plainBuf, decBuf);
+      log(ok ? '比对一致 ✅' : '比对不一致 ❌');
+    } else {
+      log('当前浏览器不支持本地文件选择 API，请手动用其它工具比对。');
+    }
+  }catch(e){
+    log('检查失败: '+e.message);
+  }
+});
+cleanBtn.addEventListener('click', async ()=>{
+  const base = location.origin;
+  try{
+    cleanBtn.disabled = true;
+    const r = await fetch(`${base}/api/clean`, { method:'POST' });
+    const j = await r.json();
+    if(j.ok){
+      log(`已清除: ${j.removed?.join(', ') || '(无)'} `);
+    } else {
+      log(`清除失败: ${j.message || '未知错误'}`);
+    }
+  }catch(e){
+    log('清除失败: '+e.message);
+  }finally{
+    cleanBtn.disabled = false;
+  }
+});
+
+loadKeysBtn.addEventListener('click', async ()=>{
+  const base = location.origin;
+  try{
+    const r = await fetch(`${base}/example/browser/keys.json`, {cache:'no-store'});
+    if(!r.ok) throw new Error('未找到 keys.json');
+    const j = await r.json();
+    privKeyInput.value = j.private_key || '';
+    if(!fileUrlInput.value){ fileUrlInput.value = `${base}/example/browser/stream.bin`; }
+    log('已加载 keys.json 并预填');
+  }catch(e){ log('加载 keys.json 失败: '+e.message); }
+});
+</script>
+</body>
+</html>

--- a/example/browser/index.html
+++ b/example/browser/index.html
@@ -28,7 +28,7 @@
 </head>
 <body>
 <h1>在浏览器中使用 Unsealer 解密流</h1>
-<p>你可以一键生成样本（自动生成 stream.bin 与 keys.json 并预填私钥），或者手动填写 URL 和私钥进行解密。</p>
+<p>你可以一键生成样本（自动生成 sealed_full.bin 与 keys.json 并预填私钥），或者手动填写 URL 和私钥进行解密。</p>
 
 <fieldset>
   <legend>输入</legend>
@@ -350,7 +350,7 @@ async function autoPrefillKeys(){
     if(r.ok){
       const j = await r.json();
       if(j?.private_key){ privKeyInput.value = j.private_key; }
-      if(!fileUrlInput.value){ fileUrlInput.value = `${base}/example/browser/stream.bin`; }
+  if(!fileUrlInput.value){ fileUrlInput.value = `${base}/example/browser/sealed_full.bin`; }
     }
   }catch(e){ /* ignore */ }
 }
@@ -456,7 +456,7 @@ genAndRunBtn.addEventListener('click', async ()=>{
     }
     // 预填但不解密
     privKeyInput.value = j.keys.private_key;
-    fileUrlInput.value = j.files.stream;
+    fileUrlInput.value = j.files.sealed_full;
     if(j.plain_sha256){
       plainHashSpan.textContent = j.plain_sha256;
       log('原始明文 MD5: '+ j.plain_sha256);
@@ -527,7 +527,7 @@ loadKeysBtn.addEventListener('click', async ()=>{
     if(!r.ok) throw new Error('未找到 keys.json');
     const j = await r.json();
     privKeyInput.value = j.private_key || '';
-    if(!fileUrlInput.value){ fileUrlInput.value = `${base}/example/browser/stream.bin`; }
+  if(!fileUrlInput.value){ fileUrlInput.value = `${base}/example/browser/sealed_full.bin`; }
     log('已加载 keys.json 并预填');
   }catch(e){ log('加载 keys.json 失败: '+e.message); }
 });

--- a/example/browser/index.html
+++ b/example/browser/index.html
@@ -18,10 +18,14 @@
       "buffer": "https://esm.sh/buffer@6.0.3?target=es2020",
       "keccak256": "https://esm.sh/keccak256@1.0.6?target=es2020",
       "aes-js": "https://esm.sh/aes-js@3.1.2?target=es2020",
-      "@noble/secp256k1": "https://esm.sh/@noble/secp256k1@2.1.0?target=es2020"
+      "@noble/secp256k1": "https://esm.sh/@noble/secp256k1@2.1.0?target=es2020",
+      "@noble/hashes/sha256": "https://esm.sh/@noble/hashes@1.4.0/sha256?target=es2020",
+      "@noble/hashes/utils": "https://esm.sh/@noble/hashes@1.4.0/utils?target=es2020"
     }
   }
   </script>
+  <!-- StreamSaver for native download progress in browser's download shelf -->
+  <script src="https://unpkg.com/streamsaver@2.0.6/StreamSaver.min.js"></script>
 </head>
 <body>
 <h1>在浏览器中使用 Unsealer 解密流</h1>
@@ -47,11 +51,11 @@
     <button id="verifyBtn">检查解密结果</button>
   </div>
   <div>
-    <button id="genAndRun">一键生成并解密</button>
+  <button id="genAndRun">一键生成加密文件</button>
     <button id="loadKeys">读取本地 keys.json</button>
     <button id="streamSaveBtn">边解密边保存</button>
     <button id="cleanBtn">清除临时文件</button>
-    <button id="chooseFileBtn">选择解密文件</button>
+  <button id="chooseFileBtn">计算解密文件的hash</button>
   </div>
 </fieldset>
 
@@ -61,6 +65,12 @@
   <div>已处理条目: <span id="processedItems">0</span></div>
   <div>已读字节: <span id="readBytes">0</span></div>
   <div>写出字节: <span id="writeBytes">0</span></div>
+</fieldset>
+
+<fieldset>
+  <legend>哈希</legend>
+  <div>原始明文 SHA-256: <span id="plainHash">未生成</span></div>
+  <div>解密文件 SHA-256: <span id="decFileHash">未计算</span></div>
 </fieldset>
 
 <h3>日志</h3>
@@ -73,8 +83,17 @@ if (!window.Buffer) {
   window.Buffer = BufferPolyfill;
 }
 
-// Load Unsealer after Buffer is available
+// Load Unsealer and HTTP tail-header transform
 const { unsealStream } = await import('../../src/browser/UnsealerBrowser.js');
+const { prepareSealedResponse } = await import('../../src/browser/SealedHttpTailHeaderTransform.js');
+const { sha256 } = await import('@noble/hashes/sha256');
+const { bytesToHex } = await import('@noble/hashes/utils');
+
+// Optionally configure StreamSaver (kept for fallback)
+if (window.streamSaver) {
+  window.streamSaver.mitm = 'https://jimmywarting.github.io/StreamSaver.js/mitm.html?version=2.0.6';
+  try{ window.streamSaver.useBlobFallback = false; }catch(e){}
+}
 
 const logDiv = document.getElementById('log');
 function log(m){const t=new Date().toISOString();logDiv.textContent += `[${t}] ${m}\n`;logDiv.scrollTop=logDiv.scrollHeight;}
@@ -93,8 +112,12 @@ const totalItemsSpan = document.getElementById('totalItems');
 const processedItemsSpan = document.getElementById('processedItems');
 const readBytesSpan = document.getElementById('readBytes');
 const writeBytesSpan = document.getElementById('writeBytes');
+const plainHashSpan = document.getElementById('plainHash');
+const decFileHashSpan = document.getElementById('decFileHash');
 
-let outputBuffers = [];
+// 仅保存少量预览，避免大文件占用内存
+let previewCaptured = false;
+let previewBuf = new Uint8Array(0);
 
 // Hidden file input fallback for browsers that don't support showOpenFilePicker or when the user aborts it
 const hiddenFileInput = document.createElement('input');
@@ -104,7 +127,57 @@ hiddenFileInput.style.display = 'none';
 document.body.appendChild(hiddenFileInput);
 
 const chooseFileBtn = document.getElementById('chooseFileBtn');
-chooseFileBtn.addEventListener('click', ()=> hiddenFileInput.click());
+chooseFileBtn.addEventListener('click', async ()=>{
+  decFileHashSpan.textContent = '计算中...';
+  try{
+    let file;
+    if(window.showOpenFilePicker){
+      try{ const [h] = await window.showOpenFilePicker({ types:[{description:'Binary', accept:{'application/octet-stream':['.bin']}}] }); file = await h.getFile(); }catch(e){ /* fallback */ }
+    }
+    if(!file){
+      await new Promise((resolve,reject)=>{
+        hiddenFileInput.onchange = ()=>{ if(hiddenFileInput.files[0]){ file = hiddenFileInput.files[0]; resolve(); } else reject(new Error('未选择文件')); };
+        hiddenFileInput.click();
+      });
+    }
+    if(!file) throw new Error('未获取到文件');
+    // 流式计算哈希，避免将整文件载入内存
+    const h = await streamHashFile(file);
+    decFileHashSpan.textContent = h;
+    log(`解密文件哈希: ${h} (${(file.size/1024/1024).toFixed(1)} MB)`);
+    const baseHash = plainHashSpan.textContent;
+    if(baseHash && baseHash.length===64){
+      log(h===baseHash ? '哈希比对一致 ✅' : '哈希比对不一致 ❌');
+    }
+  }catch(e){
+    decFileHashSpan.textContent = '失败';
+    log('计算解密文件哈希失败: '+e.message);
+  }
+});
+async function streamHashFile(file){
+  const reader = file.stream().getReader();
+  const h = sha256.create();
+  let total = 0;
+  for(;;){
+    const { value, done } = await reader.read();
+    if(done) break;
+    if(value && value.length){ h.update(value); total += value.length; }
+  }
+  return bytesToHex(h.digest());
+}
+async function streamHashResponse(resp){
+  if(!resp.ok) throw new Error('HTTP 状态: '+resp.status);
+  if(!resp.body) throw new Error('响应无 body');
+  const reader = resp.body.getReader();
+  const h = sha256.create();
+  let total = 0;
+  for(;;){
+    const { value, done } = await reader.read();
+    if(done) break;
+    if(value && value.length){ h.update(value); total += value.length; }
+  }
+  return { hex: bytesToHex(h.digest()), bytes: total };
+}
 
 async function withFileWriter(defaultName='unsealed.bin'){ 
   // Prefer File System Access API when available
@@ -132,6 +205,138 @@ async function withFileWriter(defaultName='unsealed.bin'){
   };
 }
 
+// Same constants as in SealedHttpTailHeaderTransform
+const HEADER_SIZE = 64;
+const BLOCK_INFO_SIZE = 32;
+function readUint64LE(u8, off){
+  const dv = new DataView(u8.buffer, u8.byteOffset, u8.byteLength);
+  const lo = dv.getUint32(off, true); const hi = dv.getUint32(off+4, true);
+  return hi * 0x100000000 + lo;
+}
+// Inspect sealed file by HEAD + Range(tail) to compute contentSize (plaintext total bytes)
+async function inspectSealed(url){
+  // Prefer HEAD to get total size
+  let totalSize = null;
+  try{
+    const head = await fetch(url, { method:'HEAD', cache:'no-store' });
+    if(head.ok){
+      const lenStr = head.headers.get('Content-Length');
+      if(lenStr) totalSize = Number(lenStr);
+    }
+  }catch(e){ /* ignore */ }
+  // Helper: parse total from Content-Range: bytes start-end/total
+  const parseTotal = (cr)=>{ if(!cr) return null; const m = /\/([0-9]+)$/.exec(cr); return m? Number(m[1]) : null; };
+  // Try to get tail header and total via suffix range
+  let headerBuf = null;
+  if(totalSize == null){
+    try{
+      const tail = await fetch(url, { headers: { Range: `bytes=-${HEADER_SIZE}` }, cache:'no-store' });
+      if(tail.status === 206){
+        const cr = tail.headers.get('Content-Range');
+        totalSize = parseTotal(cr);
+        headerBuf = new Uint8Array(await tail.arrayBuffer());
+      }
+    }catch(e){ /* ignore */ }
+  }
+  // If still no total, try 0-0 probe then a tail fetch
+  if(totalSize == null){
+    try{
+      const lr = await fetch(url, { headers:{ Range:'bytes=0-0' }, cache:'no-store' });
+      if(lr.status === 206){
+        totalSize = parseTotal(lr.headers.get('Content-Range'));
+      }
+    }catch(e){ /* ignore */ }
+  }
+  if(totalSize == null){
+    log('[TailHeader] 服务器未提供 Content-Length 且不支持 Range，无法精确计算明文大小，继续无大小模式');
+    return { totalSize: null, blockNumber: null, contentSize: null };
+  }
+  if(!Number.isFinite(totalSize) || totalSize < HEADER_SIZE) throw new Error('文件大小异常');
+  // Ensure we have header bytes
+  if(!headerBuf){
+    const start = totalSize - HEADER_SIZE;
+    const tail = await fetch(url, { headers: { Range: `bytes=${start}-${totalSize-1}` }, cache:'no-store' });
+    if(!(tail.status===206 || tail.status===200)) throw new Error('Range 读取尾部 header 失败: '+tail.status);
+    headerBuf = new Uint8Array(await tail.arrayBuffer());
+  }
+  if(headerBuf.length !== HEADER_SIZE){
+    log('[TailHeader] 尾部 header 长度不符，继续无大小模式');
+    return { totalSize, blockNumber: null, contentSize: null };
+  }
+  const blockNumber = readUint64LE(headerBuf, 16);
+  const contentSize = totalSize - HEADER_SIZE - BLOCK_INFO_SIZE * blockNumber;
+  if(contentSize <= 0){
+    log('[TailHeader] contentSize 计算结果 <= 0，继续无大小模式');
+    return { totalSize, blockNumber, contentSize: null };
+  }
+  return { totalSize, blockNumber, contentSize };
+}
+
+// Prefer native browser download shelf via StreamSaver when available
+async function withNativeDownloadWriter(filename, expectedSize){
+  // Prefer same-origin SW based native download to guarantee download shelf visibility
+  if ('serviceWorker' in navigator) {
+    try{
+      const reg = await navigator.serviceWorker.register('/example/browser/sw-download.js', { scope: '/example/browser/' });
+      // Wait for SW to be ready and controlling this page
+      await navigator.serviceWorker.ready;
+      async function ensureController(){
+        if (navigator.serviceWorker.controller) return navigator.serviceWorker.controller;
+        // try to message active worker directly
+        if (reg.active) return reg.active;
+        await new Promise((resolve)=>{
+          const to = setTimeout(resolve, 1500);
+          navigator.serviceWorker.addEventListener('controllerchange', ()=>{ clearTimeout(to); resolve(); }, { once:true });
+        });
+        return navigator.serviceWorker.controller || reg.active || null;
+      }
+      const controller = await ensureController();
+      if (!controller){ throw new Error('Service Worker 未接管此页面'); }
+
+      const id = Math.random().toString(36).slice(2);
+      const ch = new MessageChannel();
+      const size = (typeof expectedSize === 'number' && isFinite(expectedSize)) ? expectedSize : undefined;
+      // Post to the active/controller SW
+      let portReady = false;
+      const ackPromise = new Promise((resolve)=>{
+        const to = setTimeout(resolve, 800);
+        ch.port1.onmessage = (ev)=>{ if(ev.data && ev.data.type==='ready'){ portReady = true; clearTimeout(to); resolve(); } };
+      });
+      (reg.active || controller).postMessage({ type:'DOWNLOAD_PORT', id, name: filename, size }, [ch.port2]);
+      await ackPromise;
+
+      const downloadUrl = `/example/browser/download/unsealed?id=${encodeURIComponent(id)}`;
+      // Trigger native download in a new tab to keep current page streaming chunks
+      const w = window.open(downloadUrl, '_blank');
+      if(!w){
+        // Fallback if popup blocked: temporary anchor without download attribute (navigation)
+        const a = document.createElement('a'); a.href = downloadUrl; a.target = '_blank'; document.body.appendChild(a); a.click(); a.remove();
+      }
+      // window.open(downloadUrl, '_blank'); // optional alternative
+      log(`[Download] 使用同源 SW 原生下载，size=${size ?? '未知'}`);
+      return {
+        async write(u8){
+          // Always send a copy so the original (e.g., reusable batch buffer) is not detached
+          const copy = (u8 && u8.byteLength) ? (u8.slice ? u8.slice() : new Uint8Array(u8)) : new Uint8Array();
+          ch.port1.postMessage({ type:'chunk', data: copy }, [copy.buffer]);
+        },
+        async close(){ ch.port1.postMessage({ type:'end' }); ch.port1.close(); }
+      };
+    }catch(e){ log('[Download] 注册/使用同源 SW 失败: '+e.message); }
+  }
+  // Fallback: StreamSaver or File System Access/Blob
+  if (window.streamSaver && typeof window.streamSaver.createWriteStream === 'function'){
+    try{
+      const fileStream = window.streamSaver.createWriteStream(filename, { size: expectedSize });
+      const writer = fileStream.getWriter();
+      log(`[Download] 使用 StreamSaver 原生下载，size=${expectedSize ?? '未知'}`);
+      return { async write(u8){ await writer.write(u8); }, async close(){ await writer.close(); } };
+    }catch(e){ log('[Download] StreamSaver 失败，回退: '+e.message); }
+  }
+  log('[Download] 回退到 File System Access/Blob');
+  return withFileWriter(filename);
+}
+
 async function autoPrefillKeys(){
   try{
     const base = location.origin;
@@ -150,22 +355,56 @@ window.addEventListener('DOMContentLoaded', autoPrefillKeys);
 log('页面已加载，origin='+ location.origin);
 
 streamSaveBtn.addEventListener('click', async ()=>{
-  outputBuffers = [];
+  previewCaptured = false; previewBuf = new Uint8Array(0);
   const url = fileUrlInput.value.trim();
   const priv = privKeyInput.value.trim();
   if(!url || !priv){log('请填写 URL 和 私钥');return;}
   log('开始获取加密文件流...');
   try{
-  const resp = await fetch(url, { cache: 'no-store' });
+    // Inspect to get expected plaintext size for native download progress
+    const meta = await inspectSealed(url);
+    const expectedPlainBytes = meta.contentSize || undefined;
+    if(expectedPlainBytes){
+      log(`明文总大小(估算)=${expectedPlainBytes} 字节`);
+    } else {
+      log('未能获取明文总大小：以未知大小模式开始下载，浏览器下载栏进度可能不精确');
+    }
+    // 单段 Range 模式默认更少请求，性能更好
+    const resp = await prepareSealedResponse(url, { log, chunked: false });
     if(!resp.ok) throw new Error('HTTP 状态: '+resp.status);
     log('已连接，开始解密并写入文件...');
-    const writer = await withFileWriter('unsealed.bin');
+    // Use StreamSaver to show native download progress when available
+  const writer = await withNativeDownloadWriter('unsealed.bin', expectedPlainBytes);
+    // 增量哈希器，用于边解密边计算 SHA-256
+    const h = sha256.create();
+    // 写入批量缓冲，减少 write() 次数
+    const BATCH_SIZE = 512 * 1024; // 512KB
+    let batch = new Uint8Array(BATCH_SIZE);
+    let batchLen = 0;
     await unsealStream(resp, {
       privateKeyHex: priv,
       onChunk: async (plain)=>{
-        outputBuffers.push(plain);
-        try{ log(`收到明文块: ${plain?.length||0} 字节`); }catch(e){}
-        await writer.write(plain);
+        const len = plain?.length||0;
+        if(len===0) return;
+        // 记录预览（最多前256字节）
+        if(!previewCaptured){
+          const need = Math.min(256, len);
+          previewBuf = plain.slice(0, need);
+          previewCaptured = true;
+        }
+        // 增量哈希
+        h.update(plain);
+        // 批量写入
+        let off = 0;
+        while(off < len){
+          const can = Math.min(BATCH_SIZE - batchLen, len - off);
+          batch.set(plain.subarray(off, off+can), batchLen);
+          batchLen += can; off += can;
+          if(batchLen === BATCH_SIZE){
+            await writer.write(batch);
+            batchLen = 0;
+          }
+        }
       },
       progressHandler: (total, processed, readBytes, writeBytes)=>{
         totalItemsSpan.textContent = total;
@@ -174,18 +413,20 @@ streamSaveBtn.addEventListener('click', async ()=>{
         writeBytesSpan.textContent = writeBytes;
       }
     });
-    // 统计总明文字节
-    const totalLen = outputBuffers.reduce((acc,b)=> acc + (b?.length||0),0);
-    log(`解密结束并写入完成，总输出块: ${outputBuffers.length}，总明文字节: ${totalLen}`);
-    if(totalLen > 0){
+    // flush 剩余批次
+    if(batchLen > 0){ await writer.write(batch.subarray(0, batchLen)); }
+    // 输出预览
+    if(previewCaptured){
       try{
-        const merged = new Uint8Array(totalLen);
-        let o=0; for(const b of outputBuffers){ merged.set(b, o); o+=b.length; }
-        const preview = new TextDecoder().decode(merged.slice(0, 256));
+        const preview = new TextDecoder().decode(previewBuf);
         log('明文预览(前256字节 as UTF-8):');
         log(preview.replace(/\n/g,'\\n'));
-      }catch(e){ /* ignore preview errors */ }
+      }catch(e){ /* ignore */ }
     }
+    // 完成哈希
+    const decHash = bytesToHex(h.digest());
+    decFileHashSpan.textContent = decHash;
+    log('边解密边保存完成，解密文件哈希: ' + decHash);
     await writer.close();
   }catch(e){
     log('解密失败: '+e.message);
@@ -199,11 +440,18 @@ genAndRunBtn.addEventListener('click', async ()=>{
   const size = Number(sizeSel.value || (1024*1024*1024));
   const r = await fetch(`${base}/api/gen?size=${size}`);
     const j = await r.json();
-    if(!j.ok){ throw new Error(j.message || '生成失败'); }
-    // 预填并立即解密
+    if(!j.ok){ throw new Error(j.message || '生成失败'); }else{
+      log('生成成功');
+    }
+    // 预填但不解密
     privKeyInput.value = j.keys.private_key;
     fileUrlInput.value = j.files.stream;
-    await (async ()=>{ streamSaveBtn.click(); })();
+    if(j.plain_sha256){
+      plainHashSpan.textContent = j.plain_sha256;
+      log('原始明文哈希: '+ j.plain_sha256);
+    }
+    log('预填成功，点击‘边解密边保存’');
+    //await (async ()=>{ log('call streamSaveBtn.click()'); streamSaveBtn.click(); })();
   }catch(e){
     log('生成或预填失败: '+e.message);
   } finally {
@@ -214,39 +462,34 @@ verifyBtn.addEventListener('click', async ()=>{
   try{
     const size = Number(sizeSel.value || 0);
     if(!size){ log('请选择或输入正确的大小'); return; }
-    // 下载原始明文（按固定生成逻辑）
+    // 下载原始明文（按固定生成逻辑），流式计算哈希
     const base = location.origin;
     const plainResp = await fetch(`${base}/api/plain?size=${size}`, {cache:'no-store'});
-    if(!plainResp.ok) throw new Error('下载原始明文失败: '+plainResp.status);
-    const plainBuf = new Uint8Array(await plainResp.arrayBuffer());
-    log(`原始明文已获取：${plainBuf.length} 字节`);
+    const { hex: plainHex, bytes: plainBytes } = await streamHashResponse(plainResp);
+    plainHashSpan.textContent = plainHex;
+    log(`原始明文流式哈希完成：${plainBytes} 字节，SHA-256=${plainHex}`);
 
-    // 读取刚才保存的解密文件：优先使用 showOpenFilePicker，用户取消后降级到隐藏 file input
-    let decBuf = null;
+    // 读取解密文件并流式哈希：优先使用 showOpenFilePicker，用户取消后降级到隐藏 file input
+    let file = null;
     try{
       if(window.showOpenFilePicker){
         const [h] = await window.showOpenFilePicker({ types:[{description:'Binary', accept:{'application/octet-stream':['.bin']}}] });
-        const f = await h.getFile();
-        decBuf = new Uint8Array(await f.arrayBuffer());
+        file = await h.getFile();
       }
     }catch(e){
-      // user aborted native picker or not allowed; fallback to hidden file input
       log('本地打开被取消或不支持，使用页面文件选择作为后备');
-      decBuf = await new Promise((resolve, reject)=>{
-        hiddenFileInput.onchange = async ()=>{
-          try{ const f = hiddenFileInput.files[0]; if(!f) return reject(new Error('未选择文件')); const arr = new Uint8Array(await f.arrayBuffer()); resolve(arr); }catch(err){ reject(err); }
-        };
+    }
+    if(!file){
+      await new Promise((resolve,reject)=>{
+        hiddenFileInput.onchange = ()=>{ if(hiddenFileInput.files[0]){ file = hiddenFileInput.files[0]; resolve(); } else reject(new Error('未选择文件')); };
         hiddenFileInput.click();
       });
     }
-    if(!decBuf){ log('未能获取解密文件进行比对'); return; }
-    log(`解密文件已选择：${decBuf.length} 字节，开始比对...`);
-    const equal = (a,b)=>{
-      if(a.length!==b.length) return false;
-      for(let i=0;i<a.length;i++){ if(a[i]!==b[i]) return false; }
-      return true;
-    };
-    const ok = equal(plainBuf, decBuf);
+    if(!file){ log('未能获取解密文件进行比对'); return; }
+    const decHex = await streamHashFile(file);
+    decFileHashSpan.textContent = decHex;
+    log(`解密文件流式哈希完成：${(file.size/1024/1024).toFixed(1)} MB，SHA-256=${decHex}`);
+    const ok = (plainHex === decHex);
     log(ok ? '比对一致 ✅' : '比对不一致 ❌');
   }catch(e){
     log('检查失败: '+e.message);

--- a/example/browser/index.html
+++ b/example/browser/index.html
@@ -19,8 +19,7 @@
       "keccak256": "https://esm.sh/keccak256@1.0.6?target=es2020",
       "aes-js": "https://esm.sh/aes-js@3.1.2?target=es2020",
       "@noble/secp256k1": "https://esm.sh/@noble/secp256k1@2.1.0?target=es2020",
-      "@noble/hashes/sha256": "https://esm.sh/@noble/hashes@1.4.0/sha256?target=es2020",
-      "@noble/hashes/utils": "https://esm.sh/@noble/hashes@1.4.0/utils?target=es2020"
+      "spark-md5": "https://esm.sh/spark-md5@3.0.2?target=es2020"
     }
   }
   </script>
@@ -69,8 +68,8 @@
 
 <fieldset>
   <legend>哈希</legend>
-  <div>原始明文 SHA-256: <span id="plainHash">未生成</span></div>
-  <div>解密文件 SHA-256: <span id="decFileHash">未计算</span></div>
+  <div>原始明文 MD5: <span id="plainHash">未生成</span></div>
+  <div>解密文件 MD5: <span id="decFileHash">未计算</span></div>
 </fieldset>
 
 <h3>日志</h3>
@@ -86,8 +85,7 @@ if (!window.Buffer) {
 // Load Unsealer and HTTP tail-header transform
 const { unsealStream } = await import('../../src/browser/UnsealerBrowser.js');
 const { prepareSealedResponse } = await import('../../src/browser/SealedHttpTailHeaderTransform.js');
-const { sha256 } = await import('@noble/hashes/sha256');
-const { bytesToHex } = await import('@noble/hashes/utils');
+import SparkMD5 from 'spark-md5';
 
 // Optionally configure StreamSaver (kept for fallback)
 if (window.streamSaver) {
@@ -141,42 +139,50 @@ chooseFileBtn.addEventListener('click', async ()=>{
       });
     }
     if(!file) throw new Error('未获取到文件');
-    // 流式计算哈希，避免将整文件载入内存
+    // 流式计算 MD5，避免将整文件载入内存
     const h = await streamHashFile(file);
     decFileHashSpan.textContent = h;
-    log(`解密文件哈希: ${h} (${(file.size/1024/1024).toFixed(1)} MB)`);
+    log(`解密文件 MD5: ${h} (${(file.size/1024/1024).toFixed(1)} MB)`);
     const baseHash = plainHashSpan.textContent;
-    if(baseHash && baseHash.length===64){
+    if(baseHash && baseHash.length===32){
       log(h===baseHash ? '哈希比对一致 ✅' : '哈希比对不一致 ❌');
     }
   }catch(e){
     decFileHashSpan.textContent = '失败';
-    log('计算解密文件哈希失败: '+e.message);
+    log('计算解密文件 MD5 失败: '+e.message);
   }
 });
 async function streamHashFile(file){
   const reader = file.stream().getReader();
-  const h = sha256.create();
+  const h = new SparkMD5.ArrayBuffer();
   let total = 0;
   for(;;){
     const { value, done } = await reader.read();
     if(done) break;
-    if(value && value.length){ h.update(value); total += value.length; }
+    if(value && value.length){
+      const ab = value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength);
+      h.append(ab);
+      total += value.length;
+    }
   }
-  return bytesToHex(h.digest());
+  return h.end();
 }
 async function streamHashResponse(resp){
   if(!resp.ok) throw new Error('HTTP 状态: '+resp.status);
   if(!resp.body) throw new Error('响应无 body');
   const reader = resp.body.getReader();
-  const h = sha256.create();
+  const h = new SparkMD5.ArrayBuffer();
   let total = 0;
   for(;;){
     const { value, done } = await reader.read();
     if(done) break;
-    if(value && value.length){ h.update(value); total += value.length; }
+    if(value && value.length){
+      const ab = value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength);
+      h.append(ab);
+      total += value.length;
+    }
   }
-  return { hex: bytesToHex(h.digest()), bytes: total };
+  return { hex: h.end(), bytes: total };
 }
 
 async function withFileWriter(defaultName='unsealed.bin'){ 
@@ -375,8 +381,8 @@ streamSaveBtn.addEventListener('click', async ()=>{
     log('已连接，开始解密并写入文件...');
     // Use StreamSaver to show native download progress when available
   const writer = await withNativeDownloadWriter('unsealed.bin', expectedPlainBytes);
-    // 增量哈希器，用于边解密边计算 SHA-256
-    const h = sha256.create();
+  // 增量哈希器，用于边解密边计算 MD5
+  const h = new SparkMD5.ArrayBuffer();
     // 写入批量缓冲，减少 write() 次数
     const BATCH_SIZE = 512 * 1024; // 512KB
     let batch = new Uint8Array(BATCH_SIZE);
@@ -392,8 +398,9 @@ streamSaveBtn.addEventListener('click', async ()=>{
           previewBuf = plain.slice(0, need);
           previewCaptured = true;
         }
-        // 增量哈希
-        h.update(plain);
+  // 增量哈希（MD5）
+  const ab = plain.buffer.slice(plain.byteOffset, plain.byteOffset + plain.byteLength);
+  h.append(ab);
         // 批量写入
         let off = 0;
         while(off < len){
@@ -424,9 +431,13 @@ streamSaveBtn.addEventListener('click', async ()=>{
       }catch(e){ /* ignore */ }
     }
     // 完成哈希
-    const decHash = bytesToHex(h.digest());
+    const decHash = h.end();
     decFileHashSpan.textContent = decHash;
-    log('边解密边保存完成，解密文件哈希: ' + decHash);
+    log('边解密边保存完成，解密文件 MD5: ' + decHash);
+    const baseHash = plainHashSpan.textContent;
+    if(baseHash && baseHash.length===32){
+      log(decHash===baseHash ? '哈希比对一致 ✅' : '哈希比对不一致 ❌');
+    }
     await writer.close();
   }catch(e){
     log('解密失败: '+e.message);
@@ -448,7 +459,7 @@ genAndRunBtn.addEventListener('click', async ()=>{
     fileUrlInput.value = j.files.stream;
     if(j.plain_sha256){
       plainHashSpan.textContent = j.plain_sha256;
-      log('原始明文哈希: '+ j.plain_sha256);
+      log('原始明文 MD5: '+ j.plain_sha256);
     }
     log('预填成功，点击‘边解密边保存’');
     //await (async ()=>{ log('call streamSaveBtn.click()'); streamSaveBtn.click(); })();
@@ -460,16 +471,12 @@ genAndRunBtn.addEventListener('click', async ()=>{
 });
 verifyBtn.addEventListener('click', async ()=>{
   try{
-    const size = Number(sizeSel.value || 0);
-    if(!size){ log('请选择或输入正确的大小'); return; }
-    // 下载原始明文（按固定生成逻辑），流式计算哈希
-    const base = location.origin;
-    const plainResp = await fetch(`${base}/api/plain?size=${size}`, {cache:'no-store'});
-    const { hex: plainHex, bytes: plainBytes } = await streamHashResponse(plainResp);
-    plainHashSpan.textContent = plainHex;
-    log(`原始明文流式哈希完成：${plainBytes} 字节，SHA-256=${plainHex}`);
-
-    // 读取解密文件并流式哈希：优先使用 showOpenFilePicker，用户取消后降级到隐藏 file input
+    const serverMd5 = (plainHashSpan.textContent || '').trim();
+    if(!serverMd5 || serverMd5.length !== 32){
+      log('未获取到服务端 MD5，请先点击“一键生成加密文件”');
+      return;
+    }
+    // 读取解密文件并流式计算 MD5：优先使用 showOpenFilePicker，用户取消后降级到隐藏 file input
     let file = null;
     try{
       if(window.showOpenFilePicker){
@@ -488,8 +495,8 @@ verifyBtn.addEventListener('click', async ()=>{
     if(!file){ log('未能获取解密文件进行比对'); return; }
     const decHex = await streamHashFile(file);
     decFileHashSpan.textContent = decHex;
-    log(`解密文件流式哈希完成：${(file.size/1024/1024).toFixed(1)} MB，SHA-256=${decHex}`);
-    const ok = (plainHex === decHex);
+    log(`解密文件流式 MD5 完成：${(file.size/1024/1024).toFixed(1)} MB，MD5=${decHex}`);
+    const ok = (serverMd5 === decHex);
     log(ok ? '比对一致 ✅' : '比对不一致 ❌');
   }catch(e){
     log('检查失败: '+e.message);

--- a/example/browser/streamsaver/mitm.html
+++ b/example/browser/streamsaver/mitm.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<meta charset="utf-8" />
+<title>StreamSaver MITM</title>
+<script>
+// This is a minimal MITM page for StreamSaver to enable native download with progress.
+// It should be hosted on the same origin as the page using StreamSaver.
+
+/* eslint-disable */
+;(function(){
+  if (!('serviceWorker' in navigator)) return;
+  // Register a service worker the StreamSaver library expects by posting messages
+  const swScope = location.pathname.replace(/mitm\.html$/, '');
+  navigator.serviceWorker.register(swScope + 'sw.js', { scope: swScope })
+    .then(() => navigator.serviceWorker.ready)
+    .then(() => {
+      // Keep the page alive; StreamSaver library will handshake via postMessage
+      console.log('[StreamSaver] MITM ready, scope=', swScope);
+    })
+    .catch(err => console.error('[StreamSaver] MITM SW register error:', err));
+})();
+</script>

--- a/example/browser/streamsaver/sw.js
+++ b/example/browser/streamsaver/sw.js
@@ -1,0 +1,7 @@
+/* Minimal SW placeholder for StreamSaver. The library can also inject its own SW; this file is here
+   to keep the scope consistent and avoid cross-origin MITM.
+*/
+self.addEventListener('install', (e) => { self.skipWaiting(); });
+self.addEventListener('activate', (e) => { self.clients.claim(); });
+// The StreamSaver library will handle the message channel with the page and pipe
+// the stream through a MessagePort to the SW for native download handling.

--- a/example/browser/sw-download.js
+++ b/example/browser/sw-download.js
@@ -1,0 +1,68 @@
+// Same-origin Service Worker to stream decrypted data as a downloadable attachment
+// Frontend will post a MessagePort with an ID; SW responds to a fetch on /example/browser/download/unsealed?id=ID
+// and pipes chunks received via MessagePort into the Response stream with proper headers.
+
+/* eslint-disable no-undef */
+const downloads = new Map(); // id -> { port, name, size }
+
+self.addEventListener('install', (e) => { self.skipWaiting(); });
+self.addEventListener('activate', (e) => { e.waitUntil(self.clients.claim()); });
+
+self.addEventListener('message', (event) => {
+  const data = event.data || {};
+  if (data.type === 'DOWNLOAD_PORT' && event.ports && event.ports[0]) {
+    const { id, name, size } = data;
+    downloads.set(id, { port: event.ports[0], name: name || 'download.bin', size: size || null });
+    try { event.ports[0].postMessage({ type: 'ready', id }); } catch (e) {}
+  }
+});
+
+function streamFromPort(meta){
+  const headers = new Headers({
+    'Content-Type': 'application/octet-stream',
+    'Content-Disposition': `attachment; filename="${meta.name}"`
+  });
+  if (meta.size && Number.isFinite(meta.size)) {
+    headers.set('Content-Length', String(meta.size));
+  }
+  return new Response(new ReadableStream({
+    start(controller){
+      const port = meta.port;
+      port.onmessage = (ev)=>{
+        const msg = ev.data || {};
+        if (msg.type === 'chunk'){
+          let src = msg.data;
+          if (src && !(src instanceof Uint8Array) && src.buffer){
+            src = new Uint8Array(src.buffer, src.byteOffset||0, src.byteLength||src.length||0);
+          }
+          // Create a fresh copy to ensure the buffer is not detached by transfer
+          const chunk = (src && src.byteLength) ? new Uint8Array(src) : new Uint8Array();
+          controller.enqueue(chunk);
+        } else if (msg.type === 'end'){
+          controller.close();
+          port.close();
+        } else if (msg.type === 'error'){
+          controller.error(new Error(msg.message||'download error'));
+          port.close();
+        }
+      };
+      try{ port.start && port.start(); }catch(e){}
+    },
+    cancel(){ try{ meta.port.postMessage({ type:'cancel' }); }catch(e){} }
+  }), { headers });
+}
+
+self.addEventListener('fetch', (event) => {
+  const url = new URL(event.request.url);
+  if (url.pathname === '/example/browser/download/unsealed'){
+    const id = url.searchParams.get('id');
+    const meta = id && downloads.get(id);
+    if (!meta){
+      event.respondWith(new Response('download id not found', { status: 404 }));
+      return;
+    }
+    // one-shot, clean up after start
+    downloads.delete(id);
+    event.respondWith(streamFromPort(meta));
+  }
+});

--- a/example/http/gen-sealed-stream.js
+++ b/example/http/gen-sealed-stream.js
@@ -1,0 +1,57 @@
+import streams from 'memory-streams';
+import fs from 'fs';
+import path from 'path';
+import { createRequire } from 'module';
+import ByteBufferPkg from 'bytebuffer';
+
+const ByteBuffer = ByteBufferPkg.default || ByteBufferPkg;
+const LITTLE_ENDIAN = ByteBuffer.LITTLE_ENDIAN;
+
+const require = createRequire(import.meta.url);
+// use built commonjs bundle to avoid ESM/CJS interop issues
+const built = require('../../build/commonjs/index.cjs');
+const { DataProvider, YPCCrypto } = built;
+
+const HeaderSize = 64;
+const BlockInfoSize = 32;
+
+async function main(){
+  const sk = YPCCrypto.generatePrivateKey();
+  const pk = YPCCrypto.generatePublicKeyFromPrivateKey(sk);
+  const keyPair = { private_key: sk.toString('hex'), public_key: pk.toString('hex') };
+
+  const dp = new DataProvider(keyPair);
+  const ws = new streams.WritableStream();
+
+  const samples = [
+    'Hello, World!\n',
+    'Meta-Encryptor Browser Unsealer Test\n',
+    '一二三四五六七八九十\n',
+  ];
+  for(const s of samples){ dp.sealData(s, ws, false); }
+  dp.sealData(null, ws, true);
+  const diskBuf = ws.toBuffer();
+
+  // extract header (last 64 bytes) and compute contentSize using block_number
+  if(diskBuf.length <= HeaderSize){ throw new Error('invalid sealed buffer'); }
+  const header = diskBuf.subarray(diskBuf.length - HeaderSize);
+  const bb = ByteBuffer.wrap(header, LITTLE_ENDIAN);
+  const block_number = bb.readUint64(16).toNumber();
+  const contentSize = diskBuf.length - HeaderSize - BlockInfoSize * block_number;
+  const content = diskBuf.slice(0, contentSize);
+  const streamBuf = Buffer.concat([header, content]);
+
+  const outDir = path.resolve(process.cwd(), 'example', 'browser');
+  if(!fs.existsSync(outDir)) fs.mkdirSync(outDir, {recursive:true});
+  const sealedPath = path.join(outDir, 'sealed_full.bin');
+  const streamPath = path.join(outDir, 'stream.bin');
+  const keyPath = path.join(outDir, 'keys.json');
+  fs.writeFileSync(sealedPath, diskBuf);
+  fs.writeFileSync(streamPath, streamBuf);
+  fs.writeFileSync(keyPath, JSON.stringify(keyPair, null, 2));
+
+  console.log('[gen] wrote:', {sealedPath, streamPath, keyPath});
+  console.log('[gen] private_key:', keyPair.private_key);
+}
+
+main().catch(e=>{ console.error(e); process.exit(1); });

--- a/example/http/static-server.js
+++ b/example/http/static-server.js
@@ -1,0 +1,216 @@
+import http from 'http';
+import fs from 'fs';
+import path from 'path';
+import url from 'url';
+import { createRequire } from 'module';
+import ByteBufferPkg from 'bytebuffer';
+import { pipeline } from 'stream';
+import { promisify } from 'util';
+const pipe = promisify(pipeline);
+
+// Serve the repository root so that /example/browser/index.html can import ../../src/browser/*.js
+const ROOT = path.resolve(process.cwd());
+const BASE_PORT = Number(process.env.PORT) || 8088;
+
+function send(res, code, headers, body){
+  res.writeHead(code, headers); res.end(body);
+}
+
+function mime(file){
+  if(file.endsWith('.html')) return 'text/html; charset=utf-8';
+  if(file.endsWith('.js')) return 'text/javascript; charset=utf-8';
+  if(file.endsWith('.css')) return 'text/css; charset=utf-8';
+  if(file.endsWith('.json')) return 'application/json; charset=utf-8';
+  return 'application/octet-stream';
+}
+
+const server = http.createServer(async (req, res)=>{
+  console.log(`[req] ${req.method} ${req.url}`);
+  const parsed = url.parse(req.url);
+  let pathname = decodeURIComponent(parsed.pathname || '/');
+  // health check
+  if(req.method === 'GET' && (pathname === '/healthz' || pathname === '/.health')){
+    res.writeHead(200, {'Content-Type':'application/json','Cache-Control':'no-cache','Access-Control-Allow-Origin':'*'});
+    res.end(JSON.stringify({ ok: true, root: ROOT }));
+    return;
+  }
+  // API: generate sample sealed stream and keys
+  if(req.method === 'GET' && pathname === '/api/gen'){
+    const outDir = path.join(ROOT, 'example', 'browser');
+    try{
+      const builtPath = path.join(ROOT, 'build', 'commonjs', 'index.cjs');
+      if(!fs.existsSync(builtPath)){
+        return send(res, 500, {'Content-Type':'application/json','Access-Control-Allow-Origin':'*'}, JSON.stringify({error:'build_missing', message:'build/commonjs/index.cjs not found. Please run `yarn build`.'}));
+      }
+      const require = createRequire(import.meta.url);
+      const built = require(builtPath);
+      const { DataProvider, YPCCrypto } = built;
+
+      const ByteBuffer = ByteBufferPkg.default || ByteBufferPkg; const LITTLE_ENDIAN = ByteBuffer.LITTLE_ENDIAN;
+      const HeaderSize = 64; const BlockInfoSize = 32;
+      const sk = YPCCrypto.generatePrivateKey();
+      const pk = YPCCrypto.generatePublicKeyFromPrivateKey(sk);
+      const keyPair = { private_key: sk.toString('hex'), public_key: pk.toString('hex') };
+      if(!fs.existsSync(outDir)) fs.mkdirSync(outDir, {recursive:true});
+      const sealedPath = path.join(outDir, 'sealed_full.bin');
+      const streamPath = path.join(outDir, 'stream.bin');
+      const keyPath = path.join(outDir, 'keys.json');
+
+  // parse size param (bytes); default 1 MiB
+      const query = new url.URL(req.url, `http://${req.headers.host}`).searchParams;
+  const sizeParam = query.get('size');
+  const targetBytes = Math.max(1, Number(sizeParam || (1024*1024)));
+
+      // stream-seal to sealed_full.bin to avoid memory blow
+      const dp = new DataProvider(keyPair);
+      const ws = fs.createWriteStream(sealedPath);
+      const writer = { write: (buf)=> new Promise((resolve)=>{ if(!ws.write(buf)) ws.once('drain', resolve); else resolve(); }) };
+
+      // Generate ~targetBytes of plaintext by repeating pattern
+  // Larger unit to speed up generation; use same pattern for /api/plain to ensure exact equality
+  const baseLine = 'The quick brown fox jumps over the lazy dog. 0123456789 ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz\n';
+  const unit = baseLine.repeat(1024);
+  const unitByteLen = Buffer.byteLength(unit, 'utf8');
+      let generated = 0;
+      while(generated < targetBytes){
+        const remain = targetBytes - generated;
+        const chunkStr = remain >= unitByteLen ? unit : unit.slice(0, remain);
+        dp.sealData(chunkStr, writer, false);
+        generated += Buffer.byteLength(chunkStr, 'utf8');
+        if(generated % (unitByteLen * 64) === 0){
+          await new Promise(r=>setImmediate(r));
+        }
+      }
+      // flush and finalize header/meta
+      dp.sealData(null, writer, true);
+      await new Promise((resolve)=> ws.end(resolve));
+
+      // Read header/footer to build stream.bin as [header][content]
+  const stats = fs.statSync(sealedPath);
+  console.log('[gen] sealed_full.bin size', stats.size, 'requested', targetBytes);
+      if(stats.size <= HeaderSize) throw new Error('invalid sealed file size');
+      const headerBuf = Buffer.alloc(HeaderSize);
+      const fd = fs.openSync(sealedPath, 'r');
+      try{
+        fs.readSync(fd, headerBuf, 0, HeaderSize, stats.size - HeaderSize);
+      } finally { fs.closeSync(fd); }
+      const bb = ByteBuffer.wrap(headerBuf, LITTLE_ENDIAN);
+      const block_number = bb.readUint64(16).toNumber();
+      const contentSize = stats.size - HeaderSize - BlockInfoSize * block_number;
+      if(contentSize <= 0) throw new Error('computed contentSize <= 0');
+
+      // stream build stream.bin without loading all data
+      const ws2 = fs.createWriteStream(streamPath);
+      await new Promise((resolve, reject)=>{
+        ws2.write(headerBuf, (err)=>{ if(err) reject(err); else resolve(); });
+      });
+      const rsContent = fs.createReadStream(sealedPath, { start: 0, end: contentSize - 1 });
+      await pipe(rsContent, ws2);
+
+      fs.writeFileSync(keyPath, JSON.stringify(keyPair, null, 2));
+
+      const base = `${parsed.protocol||'http:'}//${req.headers.host}`;
+      const data = {
+        ok: true,
+        keys: keyPair,
+        files: {
+          sealed_full: `${base}/example/browser/sealed_full.bin`,
+          stream: `${base}/example/browser/stream.bin`,
+          keys: `${base}/example/browser/keys.json`
+        },
+        size: { requestedBytes: targetBytes, sealedBytes: stats.size, contentBytes: contentSize }
+      };
+      return send(res, 200, {'Content-Type':'application/json','Access-Control-Allow-Origin':'*'}, JSON.stringify(data));
+    }catch(e){
+      return send(res, 500, {'Content-Type':'application/json','Access-Control-Allow-Origin':'*'}, JSON.stringify({error:'gen_failed', message: e.message}));
+    }
+  }
+
+  // API: stream plain content of requested size for verification
+  if(req.method === 'GET' && pathname === '/api/plain'){
+    try{
+      const query = new url.URL(req.url, `http://${req.headers.host}`).searchParams;
+      const sizeParam = query.get('size');
+      const targetBytes = Math.max(0, Number(sizeParam || 0));
+      const unit = 'The quick brown fox jumps over the lazy dog. 0123456789 ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz\n';
+      const unitBuf = Buffer.from(unit, 'utf8');
+      let sent = 0;
+      res.writeHead(200, {'Content-Type':'application/octet-stream','Cache-Control':'no-store','Access-Control-Allow-Origin':'*'});
+      const writeChunk = async ()=>{
+        while(sent < targetBytes){
+          const remain = targetBytes - sent;
+          const chunk = remain >= unitBuf.length ? unitBuf : unitBuf.subarray(0, remain);
+          if(!res.write(chunk)){
+            await new Promise(r=>res.once('drain', r));
+          }
+          sent += chunk.length;
+        }
+        res.end();
+      };
+      writeChunk();
+      return;
+    }catch(e){
+      return send(res, 500, {'Content-Type':'application/json','Access-Control-Allow-Origin':'*'}, JSON.stringify({ok:false, error:'plain_failed', message: e.message}));
+    }
+  }
+  // API: clean generated files
+  if(req.method === 'POST' && pathname === '/api/clean'){
+    const outDir = path.join(ROOT, 'example', 'browser');
+    const files = ['sealed_full.bin','stream.bin','keys.json'];
+    const removed = [];
+    for(const f of files){
+      const p = path.join(outDir, f);
+      try{ if(fs.existsSync(p)){ fs.unlinkSync(p); removed.push(f); } }catch(e){ /* ignore */ }
+    }
+    return send(res, 200, {'Content-Type':'application/json','Access-Control-Allow-Origin':'*'}, JSON.stringify({ok:true, removed}));
+  }
+
+  if(pathname === '/') pathname = '/';
+  const filePath = path.join(ROOT, pathname);
+  const cors = {'Access-Control-Allow-Origin':'*','Cache-Control':'no-store'};
+  fs.stat(filePath, (err, stat)=>{
+    if(err){
+      return send(res, 404, {...cors}, 'Not Found');
+    }
+    if(stat.isDirectory()){
+      const idx = path.join(filePath, 'index.html');
+      if(fs.existsSync(idx)){
+        const stream = fs.createReadStream(idx);
+        res.writeHead(200, {...cors, 'Content-Type': mime(idx)});
+        return stream.pipe(res);
+      }
+      return send(res, 403, {...cors}, 'Forbidden');
+    }
+    const stream = fs.createReadStream(filePath);
+    res.writeHead(200, {...cors, 'Content-Type': mime(filePath)});
+    stream.pipe(res);
+  });
+});
+
+function listenWithFallback(startPort, maxAttempts = 20){
+  return new Promise((resolve, reject)=>{
+    let port = startPort;
+    const tryListen = () => {
+      server.once('error', (err)=>{
+        if(err && err.code === 'EADDRINUSE' && maxAttempts > 0){
+          console.warn(`[static-server] Port ${port} in use, trying ${port+1}...`);
+          maxAttempts -= 1; port += 1;
+          setTimeout(()=> server.listen(port), 50);
+        } else {
+          reject(err);
+        }
+      });
+      server.once('listening', ()=>{
+        console.log(`[static-server] Serving ${ROOT} at http://localhost:${port}/`);
+        resolve(port);
+      });
+      server.listen(port);
+    };
+    tryListen();
+  });
+}
+
+listenWithFallback(BASE_PORT).catch(err=>{
+  console.error('[static-server] Failed to start:', err?.message||err);
+  process.exit(1);
+});

--- a/example/vue3/App.vue
+++ b/example/vue3/App.vue
@@ -1,0 +1,423 @@
+<template>
+  <div class="app">
+    <h1>Meta-Encryptor Vue3 组件示例</h1>
+    
+    <div class="form-section">
+      <h2>配置参数</h2>
+      <div class="form-item">
+        <label>加密文件 URL:</label>
+        <input v-model="url" type="text" placeholder="例如: http://localhost:8088/example/browser/sealed_full.bin" />
+      </div>
+      <div class="form-item">
+        <label>私钥 (hex):</label>
+        <input v-model="privateKey" type="text" placeholder="64字节十六进制" />
+      </div>
+      <div class="form-item">
+        <label>下载文件名:</label>
+        <input v-model="filename" type="text" placeholder="unsealed.bin" />
+      </div>
+    </div>
+
+    <div class="component-section">
+      <h2>组件使用</h2>
+      
+      <!-- 方式1: 使用默认插槽 -->
+      <UnsealDownloader
+        :url="url"
+        :private-key="privateKey"
+        :filename="filename"
+        :on-log="handleLog"
+        @start="handleStart"
+        @progress="handleProgress"
+        @success="handleSuccess"
+        @error="handleError"
+        @complete="handleComplete"
+      />
+
+      <!-- 方式2: 使用自定义插槽 -->
+      <div class="custom-wrapper">
+        <h3>自定义按钮样式</h3>
+        <UnsealDownloader
+          :url="url"
+          :private-key="privateKey"
+          :filename="filename"
+          :on-log="handleLog"
+          @start="handleStart"
+          @progress="handleProgress"
+          @success="handleSuccess"
+          @error="handleError"
+          @complete="handleComplete"
+        >
+          <template #default="{ download, isDownloading, progress, error }">
+            <button
+              @click="download"
+              :disabled="isDownloading || !url || !privateKey"
+              class="custom-btn"
+            >
+              {{ isDownloading ? '⏳ 下载中...' : '⬇️ 开始下载' }}
+            </button>
+            <div v-if="progress" class="custom-progress">
+              <div class="progress-bar">
+                <div
+                  class="progress-fill"
+                  :style="{ width: `${(progress.processed / progress.total) * 100}%` }"
+                ></div>
+              </div>
+              <div class="progress-text">
+                进度: {{ progress.processed }} / {{ progress.total }} 块
+                ({{ formatBytes(progress.writeBytes) }})
+              </div>
+            </div>
+            <div v-if="error" class="custom-error">❌ {{ error }}</div>
+          </template>
+        </UnsealDownloader>
+      </div>
+
+      <!-- 方式3: 使用 ref 调用方法 -->
+      <div class="ref-wrapper">
+        <h3>通过 ref 调用</h3>
+        <UnsealDownloader
+          ref="downloaderRef"
+          :url="url"
+          :private-key="privateKey"
+          :filename="filename"
+          :on-log="handleLog"
+          @start="handleStart"
+          @progress="handleProgress"
+          @success="handleSuccess"
+          @error="handleError"
+          @complete="handleComplete"
+        />
+        <button @click="downloadViaRef" :disabled="!url || !privateKey" class="ref-btn">
+          通过 ref 下载
+        </button>
+        <div v-if="refStatus" class="ref-status">
+          状态: {{ refStatus }}
+        </div>
+      </div>
+    </div>
+
+    <div class="log-section">
+      <h2>日志</h2>
+      <div class="log-container">
+        <div v-for="(log, index) in logs" :key="index" class="log-item">
+          {{ log }}
+        </div>
+      </div>
+      <button @click="clearLogs" class="clear-btn">清除日志</button>
+    </div>
+
+    <div class="status-section">
+      <h2>状态信息</h2>
+      <div class="status-item">
+        <strong>最后事件:</strong> {{ lastEvent }}
+      </div>
+      <div class="status-item" v-if="lastProgress">
+        <strong>进度:</strong>
+        <ul>
+          <li>总块数: {{ lastProgress.total }}</li>
+          <li>已处理: {{ lastProgress.processed }}</li>
+          <li>已读: {{ formatBytes(lastProgress.readBytes) }}</li>
+          <li>已写: {{ formatBytes(lastProgress.writeBytes) }}</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import UnsealDownloader from '@/browser/UnsealDownloader.vue'
+
+const url = ref('http://localhost:8088/example/browser/sealed_full.bin')
+const privateKey = ref('')
+const filename = ref('unsealed.bin')
+
+const logs = ref([])
+const lastEvent = ref('')
+const lastProgress = ref(null)
+const refStatus = ref('')
+const downloaderRef = ref(null)
+
+const formatBytes = (bytes) => {
+  if (!bytes) return '0 B'
+  const k = 1024
+  const sizes = ['B', 'KB', 'MB', 'GB']
+  const i = Math.floor(Math.log(bytes) / Math.log(k))
+  return Math.round((bytes / Math.pow(k, i)) * 100) / 100 + ' ' + sizes[i]
+}
+
+const handleLog = (message) => {
+  const timestamp = new Date().toLocaleTimeString()
+  logs.value.push(`[${timestamp}] ${message}`)
+  console.log(message)
+}
+
+const handleStart = () => {
+  lastEvent.value = '开始下载'
+  handleLog('下载开始')
+}
+
+const handleProgress = (progressData) => {
+  lastProgress.value = progressData
+  lastEvent.value = '进度更新'
+}
+
+const handleSuccess = (data) => {
+  lastEvent.value = `下载成功: ${data.filename}`
+  handleLog(`下载成功: ${data.filename}`)
+}
+
+const handleError = (error) => {
+  lastEvent.value = `下载失败: ${error.message}`
+  handleLog(`下载失败: ${error.message}`)
+}
+
+const handleComplete = (data) => {
+  lastEvent.value = `下载完成: ${data.status}`
+  handleLog(`下载完成: ${data.status}`)
+}
+
+const clearLogs = () => {
+  logs.value = []
+}
+
+const downloadViaRef = async () => {
+  if (!downloaderRef.value) return
+  try {
+    await downloaderRef.value.download()
+    refStatus.value = '下载已触发'
+  } catch (e) {
+    refStatus.value = `错误: ${e.message}`
+  }
+}
+
+// 自动加载私钥（如果可用）
+async function loadKeys() {
+  try {
+    const base = window.location.origin
+    const r = await fetch(`${base}/example/browser/keys.json`, { cache: 'no-store' })
+    if (r.ok) {
+      const j = await r.json()
+      if (j?.private_key) {
+        privateKey.value = j.private_key
+        handleLog('已自动加载私钥')
+      }
+    }
+  } catch (e) {
+    // ignore
+  }
+}
+
+loadKeys()
+</script>
+
+<style>
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+  background: #f5f5f5;
+}
+
+.app {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+h1 {
+  margin-bottom: 30px;
+  color: #333;
+}
+
+h2 {
+  margin: 20px 0 15px;
+  color: #555;
+  font-size: 18px;
+}
+
+h3 {
+  margin: 15px 0 10px;
+  color: #666;
+  font-size: 16px;
+}
+
+.form-section,
+.component-section,
+.log-section,
+.status-section {
+  background: white;
+  padding: 20px;
+  margin-bottom: 20px;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.form-item {
+  margin-bottom: 15px;
+}
+
+.form-item label {
+  display: block;
+  margin-bottom: 5px;
+  font-weight: 500;
+  color: #333;
+}
+
+.form-item input {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 14px;
+}
+
+.form-item input:focus {
+  outline: none;
+  border-color: #409eff;
+}
+
+.custom-wrapper,
+.ref-wrapper {
+  margin-top: 20px;
+  padding: 15px;
+  background: #f9f9f9;
+  border-radius: 4px;
+}
+
+.custom-btn {
+  padding: 10px 20px;
+  font-size: 16px;
+  border: none;
+  border-radius: 6px;
+  background: #409eff;
+  color: white;
+  cursor: pointer;
+  transition: background 0.3s;
+}
+
+.custom-btn:hover:not(:disabled) {
+  background: #66b1ff;
+}
+
+.custom-btn:disabled {
+  background: #c0c4cc;
+  cursor: not-allowed;
+}
+
+.custom-progress {
+  margin-top: 15px;
+}
+
+.progress-bar {
+  width: 100%;
+  height: 20px;
+  background: #e4e7ed;
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  background: #409eff;
+  transition: width 0.3s;
+}
+
+.progress-text {
+  margin-top: 5px;
+  font-size: 12px;
+  color: #666;
+}
+
+.custom-error {
+  margin-top: 10px;
+  padding: 8px;
+  background: #fef0f0;
+  color: #f56c6c;
+  border-radius: 4px;
+  font-size: 14px;
+}
+
+.ref-btn {
+  padding: 8px 16px;
+  font-size: 14px;
+  border: 1px solid #409eff;
+  border-radius: 4px;
+  background: white;
+  color: #409eff;
+  cursor: pointer;
+}
+
+.ref-btn:hover:not(:disabled) {
+  background: #ecf5ff;
+}
+
+.ref-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.ref-status {
+  margin-top: 10px;
+  font-size: 14px;
+  color: #666;
+}
+
+.log-container {
+  max-height: 300px;
+  overflow-y: auto;
+  background: #1e1e1e;
+  color: #d4d4d4;
+  padding: 15px;
+  border-radius: 4px;
+  font-family: 'Courier New', monospace;
+  font-size: 12px;
+  margin-bottom: 10px;
+}
+
+.log-item {
+  margin-bottom: 5px;
+  line-height: 1.5;
+}
+
+.clear-btn {
+  padding: 6px 12px;
+  font-size: 12px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  background: white;
+  cursor: pointer;
+}
+
+.clear-btn:hover {
+  background: #f5f5f5;
+}
+
+.status-section {
+  background: #f0f9ff;
+}
+
+.status-item {
+  margin-bottom: 10px;
+}
+
+.status-item strong {
+  color: #333;
+}
+
+.status-item ul {
+  margin-left: 20px;
+  margin-top: 5px;
+}
+
+.status-item li {
+  margin-bottom: 5px;
+  color: #666;
+}
+</style>
+

--- a/example/vue3/README.md
+++ b/example/vue3/README.md
@@ -1,0 +1,148 @@
+# Meta-Encryptor Vue3 组件示例
+
+这是一个使用 Vue3 组件封装边下载边解密功能的示例项目。
+
+## 安装依赖
+
+```bash
+cd example/vue3
+npm install
+# 或
+yarn install
+```
+
+## 启动开发服务器
+
+首先确保后端服务器正在运行：
+
+```bash
+# 在项目根目录
+yarn serve:example
+```
+
+然后启动 Vue3 示例：
+
+```bash
+cd example/vue3
+npm run dev
+```
+
+访问 http://localhost:5173
+
+## 组件使用
+
+### 基本用法
+
+```vue
+<template>
+  <UnsealDownloader
+    :url="encryptedFileUrl"
+    :private-key="privateKey"
+    :filename="'decrypted.bin'"
+    @success="handleSuccess"
+    @error="handleError"
+  />
+</template>
+
+<script setup>
+import UnsealDownloader from '@/browser/UnsealDownloader.vue'
+
+const encryptedFileUrl = 'http://localhost:8088/example/browser/sealed_full.bin'
+const privateKey = 'your-private-key-hex'
+
+const handleSuccess = (data) => {
+  console.log('下载成功:', data.filename)
+}
+
+const handleError = (error) => {
+  console.error('下载失败:', error)
+}
+</script>
+```
+
+### 使用自定义插槽
+
+```vue
+<template>
+  <UnsealDownloader
+    :url="encryptedFileUrl"
+    :private-key="privateKey"
+  >
+    <template #default="{ download, isDownloading, progress, error }">
+      <button @click="download" :disabled="isDownloading">
+        {{ isDownloading ? '下载中...' : '开始下载' }}
+      </button>
+      <div v-if="progress">
+        进度: {{ progress.processed }} / {{ progress.total }}
+      </div>
+      <div v-if="error" class="error">{{ error }}</div>
+    </template>
+  </UnsealDownloader>
+</template>
+```
+
+### 通过 ref 调用
+
+```vue
+<template>
+  <UnsealDownloader
+    ref="downloader"
+    :url="encryptedFileUrl"
+    :private-key="privateKey"
+  />
+  <button @click="handleDownload">下载</button>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import UnsealDownloader from '@/browser/UnsealDownloader.vue'
+
+const downloader = ref(null)
+
+const handleDownload = async () => {
+  await downloader.value.download()
+}
+</script>
+```
+
+## Props
+
+| 属性 | 类型 | 必填 | 默认值 | 说明 |
+|------|------|------|--------|------|
+| url | String | 是 | - | 加密文件的URL |
+| privateKey | String | 是 | - | 私钥（hex格式） |
+| filename | String | 否 | 'unsealed.bin' | 下载文件名 |
+| serviceWorkerPath | String | 否 | null | Service Worker路径（用于原生下载进度） |
+| serviceWorkerScope | String | 否 | null | Service Worker作用域 |
+| chunked | Boolean | 否 | false | 是否启用分块模式 |
+| onLog | Function | 否 | null | 日志回调函数 |
+
+## Events
+
+| 事件名 | 参数 | 说明 |
+|--------|------|------|
+| start | - | 下载开始 |
+| progress | progress | 进度更新（包含 total, processed, readBytes, writeBytes） |
+| success | data | 下载成功（包含 filename） |
+| error | error | 下载失败（包含错误信息） |
+| complete | data | 下载完成（包含 status 和 error） |
+
+## 插槽
+
+| 插槽名 | 作用域 | 说明 |
+|--------|--------|------|
+| default | { download, isDownloading, progress, error, status } | 自定义组件内容 |
+
+## 暴露的方法
+
+通过 ref 可以调用以下方法：
+
+- `download()`: 触发下载
+
+## 暴露的状态
+
+- `isDownloading`: 是否正在下载
+- `progress`: 进度信息
+- `error`: 错误信息
+- `status`: 状态（idle, downloading, success, error）
+

--- a/example/vue3/index.html
+++ b/example/vue3/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Meta-Encryptor Vue3 组件示例</title>
+  <!-- StreamSaver for native download progress (可选) -->
+  <script src="https://unpkg.com/streamsaver@2.0.6/StreamSaver.min.js"></script>
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module" src="./main.js"></script>
+</body>
+</html>
+

--- a/example/vue3/main.js
+++ b/example/vue3/main.js
@@ -1,0 +1,22 @@
+import { createApp } from 'vue'
+import App from './App.vue'
+
+// 确保 Buffer polyfill 存在（如果需要）
+if (typeof window !== 'undefined' && !window.Buffer) {
+  import('buffer').then(({ Buffer }) => {
+    window.Buffer = Buffer
+  })
+}
+
+// 可选：配置 StreamSaver（如果需要）
+if (window.streamSaver) {
+  window.streamSaver.mitm = 'https://jimmywarting.github.io/StreamSaver.js/mitm.html?version=2.0.6'
+  try {
+    window.streamSaver.useBlobFallback = false
+  } catch (e) {
+    // ignore
+  }
+}
+
+createApp(App).mount('#app')
+

--- a/example/vue3/package.json
+++ b/example/vue3/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "meta-encryptor-vue3-example",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "vue": "^3.4.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.0.0",
+    "vite": "^5.0.0",
+    "buffer": "^6.0.3"
+  }
+}
+

--- a/example/vue3/public/sw-download.js
+++ b/example/vue3/public/sw-download.js
@@ -1,0 +1,70 @@
+// Same-origin Service Worker to stream decrypted data as a downloadable attachment
+// Frontend will post a MessagePort with an ID; SW responds to a fetch on /download/unsealed?id=ID
+// and pipes chunks received via MessagePort into the Response stream with proper headers.
+
+/* eslint-disable no-undef */
+const downloads = new Map(); // id -> { port, name, size }
+
+self.addEventListener('install', (e) => { self.skipWaiting(); });
+self.addEventListener('activate', (e) => { e.waitUntil(self.clients.claim()); });
+
+self.addEventListener('message', (event) => {
+  const data = event.data || {};
+  if (data.type === 'DOWNLOAD_PORT' && event.ports && event.ports[0]) {
+    const { id, name, size } = data;
+    downloads.set(id, { port: event.ports[0], name: name || 'download.bin', size: size || null });
+    try { event.ports[0].postMessage({ type: 'ready', id }); } catch (e) {}
+  }
+});
+
+function streamFromPort(meta){
+  const headers = new Headers({
+    'Content-Type': 'application/octet-stream',
+    'Content-Disposition': `attachment; filename="${meta.name}"`
+  });
+  if (meta.size && Number.isFinite(meta.size)) {
+    headers.set('Content-Length', String(meta.size));
+  }
+  return new Response(new ReadableStream({
+    start(controller){
+      const port = meta.port;
+      port.onmessage = (ev)=>{
+        const msg = ev.data || {};
+        if (msg.type === 'chunk'){
+          let src = msg.data;
+          if (src && !(src instanceof Uint8Array) && src.buffer){
+            src = new Uint8Array(src.buffer, src.byteOffset||0, src.byteLength||src.length||0);
+          }
+          // Create a fresh copy to ensure the buffer is not detached by transfer
+          const chunk = (src && src.byteLength) ? new Uint8Array(src) : new Uint8Array();
+          controller.enqueue(chunk);
+        } else if (msg.type === 'end'){
+          controller.close();
+          port.close();
+        } else if (msg.type === 'error'){
+          controller.error(new Error(msg.message||'download error'));
+          port.close();
+        }
+      };
+      try{ port.start && port.start(); }catch(e){}
+    },
+    cancel(){ try{ meta.port.postMessage({ type:'cancel' }); }catch(e){} }
+  }), { headers });
+}
+
+self.addEventListener('fetch', (event) => {
+  const url = new URL(event.request.url);
+  // 拦截下载路径
+  if (url.pathname === '/download/unsealed' || url.pathname.endsWith('/download/unsealed')){
+    const id = url.searchParams.get('id');
+    const meta = id && downloads.get(id);
+    if (!meta){
+      event.respondWith(new Response('download id not found', { status: 404 }));
+      return;
+    }
+    // one-shot, clean up after start
+    downloads.delete(id);
+    event.respondWith(streamFromPort(meta));
+  }
+});
+

--- a/example/vue3/vite.config.js
+++ b/example/vue3/vite.config.js
@@ -1,0 +1,50 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+import { resolve } from 'path'
+import { copyFileSync, existsSync } from 'fs'
+
+// 自动从node_modules复制Service Worker文件到public目录
+// 这样用户无需手动复制，构建时会自动处理
+function copyServiceWorker() {
+  // 优先尝试从node_modules（npm包）复制
+  const swSourceFromNpm = resolve(__dirname, '../../node_modules/@yeez-tech/meta-encryptor/src/browser/sw-download.js')
+  // 回退到本地源码路径（开发时）
+  const swSourceFromLocal = resolve(__dirname, '../../src/browser/sw-download.js')
+  const swDest = resolve(__dirname, './public/sw-download.js')
+  
+  let swSource = null
+  if (existsSync(swSourceFromNpm)) {
+    swSource = swSourceFromNpm
+  } else if (existsSync(swSourceFromLocal)) {
+    swSource = swSourceFromLocal
+  }
+  
+  if (swSource && !existsSync(swDest)) {
+    copyFileSync(swSource, swDest)
+    console.log('[Vite] 已自动复制 Service Worker 文件到 public 目录')
+  }
+}
+
+copyServiceWorker()
+
+export default defineConfig({
+  plugins: [vue()],
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, '../../src')
+    }
+  },
+  server: {
+    port: 5173,
+    proxy: {
+      '/example': {
+        target: 'http://localhost:8088',
+        changeOrigin: true
+      }
+    }
+  },
+  optimizeDeps: {
+    include: ['buffer']
+  }
+})
+

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -6,5 +6,9 @@ module.exports = {
       configFile: './babel.config.cjs',
     }],
   },
+  transformIgnorePatterns: [
+    // transform noble secp for ESM export
+    'node_modules/(?!(?:@noble/secp256k1)/)'
+  ],
   testTimeout: 1000 * 60 * 10
 };

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "scripts": {
         "build": "rollup-cli-build --no-uglify",
         "test": "jest",
+        "serve:example": "node example/http/static-server.js",
+        "gen:sealed": "node example/http/gen-sealed-stream.js",
         "version": "changeset version",
         "release": "changeset publish"
     },
@@ -48,7 +50,9 @@
         "keccak256": "^1.0.6",
         "loglevel": "^1.9.1",
         "memory-streams": "^0.1.3",
-        "secp256k1": "^5.0.1"
+        "secp256k1": "^5.0.1",
+        "@noble/secp256k1": "^2.1.0",
+        "aes-js": "^3.1.2"
     },
     "publishConfig": {
         "access": "public"

--- a/package.json
+++ b/package.json
@@ -1,10 +1,22 @@
 {
     "name": "@yeez-tech/meta-encryptor",
-    "version": "4.0.6",
+    "version": "4.2.0",
     "description": "Data Seal/Unseal for Fidelius",
-    "main": "build/commonjs/index.cjs",
-    "module": "build/es/index.js",
+    "main": "build/commonjs/index.node.cjs",
+    "module": "build/es/index.node.js",
     "types": "src/index.d.ts",
+    "exports": {
+        ".": {
+            "browser": {
+                "import": "./build/es/index.browser.js"
+            },
+            "node": {
+                "import": "./build/es/index.node.js",
+                "require": "./build/commonjs/index.node.cjs"
+            },
+            "default": "./build/es/index.node.js"
+        }
+    },
     "type": "module",
     "files": [
         "build",
@@ -55,6 +67,7 @@
         "memory-streams": "^0.1.3",
         "secp256k1": "^5.0.1",
         "@noble/secp256k1": "^2.1.0",
+        "@noble/hashes": "^1.3.3",
         "aes-js": "4.0.0-beta.5"
     },
     "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@yeez-tech/meta-encryptor",
-    "version": "4.0.0",
+    "version": "4.0.3",
     "description": "Data Seal/Unseal for Fidelius",
     "main": "build/commonjs/index.cjs",
     "module": "build/es/index.js",
@@ -8,7 +8,10 @@
     "type": "module",
     "files": [
         "build",
-        "src/index.d.ts"
+        "src/index.d.ts",
+        "src/browser",
+        "src/header_util.js",
+        "src/limits.js"
     ],
     "scripts": {
         "build": "rollup-cli-build --no-uglify",
@@ -52,7 +55,7 @@
         "memory-streams": "^0.1.3",
         "secp256k1": "^5.0.1",
         "@noble/secp256k1": "^2.1.0",
-        "aes-js": "^3.1.2"
+        "aes-js": "4.0.0-beta.5"
     },
     "publishConfig": {
         "access": "public"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@yeez-tech/meta-encryptor",
-    "version": "4.0.3",
+    "version": "4.0.6",
     "description": "Data Seal/Unseal for Fidelius",
     "main": "build/commonjs/index.cjs",
     "module": "build/es/index.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,11 @@
 import commonjs from "@rollup/plugin-commonjs";
 import json from "@rollup/plugin-json";
 export default {
-  input: ["src/index.js", "src/utils.js"],
+  input: [
+    "src/index.node.js",
+    "src/index.browser.js",
+    "src/utils.js"
+  ],
   plugins: [
     json(),
     commonjs({
@@ -16,6 +20,7 @@ export default {
     {
       dir: "build/es",
       format: "es",
+      entryFileNames: "[name].js",
     },
     {
       dir: "build/commonjs",

--- a/src/Sealer.js
+++ b/src/Sealer.js
@@ -74,7 +74,8 @@ export class Sealer extends Transform {
     if (this.accumulatedBuffer.length >= this.threshold) {
       let rs = new streams.WritableStream()
       this.DP.sealData(this.accumulatedBuffer, rs, false);
-      this.push(rs.toBuffer());
+      const out = rs.toBuffer();
+      this.push(Buffer.isBuffer(out) ? out : Buffer.from(out));
       this.accumulatedBuffer = Buffer.alloc(0);
     }
     callback();
@@ -86,7 +87,8 @@ export class Sealer extends Transform {
       this.DP.sealData(this.accumulatedBuffer, rs, false);
     }
     let ret = this.DP.sealData(null, rs, true);
-    this.push(rs.toBuffer());
+    const out = rs.toBuffer();
+    this.push(Buffer.isBuffer(out) ? out : Buffer.from(out));
     this.accumulatedBuffer = Buffer.alloc(0);
     callback();
   }

--- a/src/browser/README.md
+++ b/src/browser/README.md
@@ -1,0 +1,524 @@
+# Meta-Encryptor 浏览器端命令式 API
+
+## 快速开始
+
+```javascript
+import { downloadUnsealed } from "@yeez-tech/meta-encryptor/src/browser/downloadUnsealed.js";
+
+// 基本使用
+await downloadUnsealed({
+  url: "http://example.com/encrypted.bin",
+  privateKey: "your-private-key-hex-64-bytes",
+  filename: "decrypted.bin",
+});
+```
+
+## 安装
+
+```bash
+npm install @yeez-tech/meta-encryptor
+```
+
+## API 文档
+
+### downloadUnsealed(options)
+
+下载并解密加密文件。
+
+#### 参数
+
+| 参数         | 类型     | 必填 | 说明                                                         |
+| ------------ | -------- | ---- | ------------------------------------------------------------ |
+| `url`        | string   | ✅   | 加密文件的 URL（必须支持 HTTP Range 请求）                   |
+| `privateKey` | string   | ✅   | 私钥（hex 格式，64 字节）                                    |
+| `filename`   | string   | ✅   | 下载文件名（必需，无默认值）                                 |
+| `onLog`      | function | ❌   | 日志回调 `(message: string) => void`                         |
+| `onProgress` | function | ❌   | 进度回调 `(total, processed, readBytes, writeBytes) => void` |
+| `onSuccess`  | function | ❌   | 成功回调 `(data: { filename }) => void`                      |
+| `onError`    | function | ❌   | 错误回调 `(error: Error) => void`                            |
+
+#### 返回值
+
+`Promise<void>` - 如果提供了 `onError`，错误会被回调处理；否则会抛出异常。
+
+#### 注意事项
+
+- **文件名必需**：`filename` 参数是必需的，没有默认值
+- **私钥格式**：必须是 64 字节的十六进制字符串（128 个字符）
+- **URL 要求**：必须支持 HTTP Range 请求（用于读取文件头部和分块下载）
+- **浏览器环境**：此 API 只能在浏览器环境中使用，不支持 Node.js 或 SSR 服务端渲染
+
+## 使用示例
+
+### 示例 1：基本使用
+
+```javascript
+import { downloadUnsealed } from "@yeez-tech/meta-encryptor/src/browser/downloadUnsealed.js";
+
+button.addEventListener("click", async () => {
+  try {
+    await downloadUnsealed({
+      url: "http://example.com/encrypted.bin",
+      privateKey:
+        "b574dbe4a665c8186102454aef49deb1f213a37c28b083d2d8995db10f7dcadc",
+      filename: "decrypted.bin",
+    });
+    console.log("下载完成");
+  } catch (error) {
+    console.error("下载失败:", error);
+  }
+});
+```
+
+### 示例 2：完整回调
+
+```javascript
+import { downloadUnsealed } from "@yeez-tech/meta-encryptor/src/browser/downloadUnsealed.js";
+
+await downloadUnsealed({
+  url: "http://example.com/encrypted.bin",
+  privateKey: "your-private-key-hex",
+  filename: "decrypted.bin",
+  onLog: (message) => {
+    console.log("[Download]", message);
+  },
+  onProgress: (total, processed, readBytes, writeBytes) => {
+    console.log(`进度: ${processed}/${total} 块`);
+    console.log(`已读: ${readBytes} 字节`);
+    console.log(`已写: ${writeBytes} 字节`);
+  },
+  onSuccess: (data) => {
+    console.log("下载成功:", data.filename);
+    alert("下载完成！");
+  },
+  onError: (error) => {
+    console.error("下载失败:", error.message);
+    alert("下载失败: " + error.message);
+  },
+});
+```
+
+### 示例 3：Vue3 中使用
+
+```vue
+<template>
+  <button @click="handleDownload" :disabled="isDownloading">
+    {{ isDownloading ? "下载中..." : "下载" }}
+  </button>
+</template>
+
+<script setup>
+import { ref } from "vue";
+import { downloadUnsealed } from "@yeez-tech/meta-encryptor/src/browser/downloadUnsealed.js";
+
+const isDownloading = ref(false);
+
+const handleDownload = async () => {
+  isDownloading.value = true;
+  try {
+    await downloadUnsealed({
+      url: "http://example.com/encrypted.bin",
+      privateKey: "your-private-key-hex",
+      filename: "decrypted.bin",
+      onProgress: (total, processed, readBytes, writeBytes) => {
+        console.log(`进度: ${processed}/${total} 块`);
+        console.log(`已读: ${readBytes} 字节，已写: ${writeBytes} 字节`);
+      },
+    });
+  } catch (error) {
+    console.error("下载失败:", error);
+  } finally {
+    isDownloading.value = false;
+  }
+};
+</script>
+```
+
+### 示例 4：React 中使用
+
+```jsx
+import { useState } from "react";
+import { downloadUnsealed } from "@yeez-tech/meta-encryptor/src/browser/downloadUnsealed.js";
+
+function DownloadButton() {
+  const [isDownloading, setIsDownloading] = useState(false);
+
+  const handleDownload = async () => {
+    setIsDownloading(true);
+    try {
+      await downloadUnsealed({
+        url: "http://example.com/encrypted.bin",
+        privateKey: "your-private-key-hex",
+        filename: "decrypted.bin",
+        onProgress: (total, processed, readBytes, writeBytes) => {
+          console.log(`进度: ${processed}/${total} 块`);
+          console.log(`已读: ${readBytes} 字节，已写: ${writeBytes} 字节`);
+        },
+      });
+    } catch (error) {
+      console.error("下载失败:", error);
+    } finally {
+      setIsDownloading(false);
+    }
+  };
+
+  return (
+    <button onClick={handleDownload} disabled={isDownloading}>
+      {isDownloading ? "下载中..." : "下载"}
+    </button>
+  );
+}
+```
+
+## SSR 支持
+
+此 API **仅支持浏览器环境**，不支持 Node.js 或 SSR 服务端渲染。在 SSR 项目中使用时，需要：
+
+### 推荐方案：弹窗 + 动态导入（最安全）
+
+**最佳实践**：在弹窗的点击事件中动态导入组件，确保代码只在客户端执行。
+
+#### Next.js 示例
+
+```javascript
+"use client"; // Next.js 13+ App Router
+
+import { useState } from "react";
+
+function DownloadPage() {
+  const [showModal, setShowModal] = useState(false);
+
+  // 第一步：点击下载按钮，显示弹窗
+  const handleOpenModal = () => {
+    setShowModal(true);
+  };
+
+  // 第二步：在弹窗内点击确认，动态导入并执行下载
+  const handleConfirmDownload = async () => {
+    try {
+      // 动态导入，确保只在客户端执行
+      const { downloadUnsealed } = await import(
+        "@yeez-tech/meta-encryptor/src/browser/downloadUnsealed.js"
+      );
+
+      await downloadUnsealed({
+        url: "http://example.com/encrypted.bin",
+        privateKey: "your-private-key-hex",
+        filename: "decrypted.bin",
+        onProgress: (total, processed, readBytes, writeBytes) => {
+          console.log(`进度: ${processed}/${total} 块`);
+        },
+        onSuccess: () => {
+          setShowModal(false);
+          alert("下载完成！");
+        },
+        onError: (error) => {
+          alert("下载失败: " + error.message);
+        },
+      });
+    } catch (error) {
+      console.error("下载失败:", error);
+      alert("下载失败: " + error.message);
+    }
+  };
+
+  return (
+    <div>
+      <button onClick={handleOpenModal}>下载文件</button>
+
+      {showModal && (
+        <div className="modal">
+          <div className="modal-content">
+            <h3>确认下载</h3>
+            <p>点击确认开始下载并解密文件</p>
+            <button onClick={handleConfirmDownload}>确认下载</button>
+            <button onClick={() => setShowModal(false)}>取消</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+#### Nuxt.js 示例
+
+```vue
+<template>
+  <div>
+    <button @click="showModal = true">下载文件</button>
+
+    <div v-if="showModal" class="modal">
+      <div class="modal-content">
+        <h3>确认下载</h3>
+        <p>点击确认开始下载并解密文件</p>
+        <button @click="handleConfirmDownload">确认下载</button>
+        <button @click="showModal = false">取消</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from "vue";
+
+const showModal = ref(false);
+
+// 在弹窗内点击确认，动态导入并执行下载
+const handleConfirmDownload = async () => {
+  try {
+    // 动态导入，确保只在客户端执行
+    const { downloadUnsealed } = await import(
+      "@yeez-tech/meta-encryptor/src/browser/downloadUnsealed.js"
+    );
+
+    await downloadUnsealed({
+      url: "http://example.com/encrypted.bin",
+      privateKey: "your-private-key-hex",
+      filename: "decrypted.bin",
+      onSuccess: () => {
+        showModal.value = false;
+        alert("下载完成！");
+      },
+      onError: (error) => {
+        alert("下载失败: " + error.message);
+      },
+    });
+  } catch (error) {
+    console.error("下载失败:", error);
+    alert("下载失败: " + error.message);
+  }
+};
+</script>
+```
+
+#### 原生 JavaScript 示例
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>下载示例</title>
+  </head>
+  <body>
+    <button id="downloadBtn">下载文件</button>
+
+    <div id="modal" style="display: none;">
+      <div class="modal-content">
+        <h3>确认下载</h3>
+        <p>点击确认开始下载并解密文件</p>
+        <button id="confirmBtn">确认下载</button>
+        <button id="cancelBtn">取消</button>
+      </div>
+    </div>
+
+    <script type="module">
+      const downloadBtn = document.getElementById("downloadBtn");
+      const modal = document.getElementById("modal");
+      const confirmBtn = document.getElementById("confirmBtn");
+      const cancelBtn = document.getElementById("cancelBtn");
+
+      // 第一步：点击下载按钮，显示弹窗
+      downloadBtn.addEventListener("click", () => {
+        modal.style.display = "block";
+      });
+
+      // 第二步：在弹窗内点击确认，动态导入并执行下载
+      confirmBtn.addEventListener("click", async () => {
+        try {
+          // 动态导入，确保只在客户端执行
+          const { downloadUnsealed } = await import(
+            "@yeez-tech/meta-encryptor/src/browser/downloadUnsealed.js"
+          );
+
+          await downloadUnsealed({
+            url: "http://example.com/encrypted.bin",
+            privateKey: "your-private-key-hex",
+            filename: "decrypted.bin",
+            onSuccess: () => {
+              modal.style.display = "none";
+              alert("下载完成！");
+            },
+            onError: (error) => {
+              alert("下载失败: " + error.message);
+            },
+          });
+        } catch (error) {
+          console.error("下载失败:", error);
+          alert("下载失败: " + error.message);
+        }
+      });
+
+      cancelBtn.addEventListener("click", () => {
+        modal.style.display = "none";
+      });
+    </script>
+  </body>
+</html>
+```
+
+### 其他 SSR 方案
+
+#### Next.js 客户端组件
+
+```javascript
+"use client"; // Next.js 13+ App Router
+
+import { useEffect, useState } from "react";
+
+function DownloadButton() {
+  const [isClient, setIsClient] = useState(false);
+
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
+
+  const handleDownload = async () => {
+    if (!isClient) return;
+
+    // 动态导入，确保只在客户端执行
+    const { downloadUnsealed } = await import(
+      "@yeez-tech/meta-encryptor/src/browser/downloadUnsealed.js"
+    );
+
+    await downloadUnsealed({
+      url: "http://example.com/encrypted.bin",
+      privateKey: "your-private-key-hex",
+      filename: "decrypted.bin",
+    });
+  };
+
+  if (!isClient) return null;
+
+  return <button onClick={handleDownload}>下载</button>;
+}
+```
+
+#### Nuxt.js 客户端检查
+
+```vue
+<template>
+  <button @click="handleDownload" :disabled="!isClient">下载</button>
+</template>
+
+<script setup>
+import { ref, onMounted } from "vue";
+
+const isClient = ref(false);
+
+onMounted(() => {
+  isClient.value = true;
+});
+
+const handleDownload = async () => {
+  if (!isClient.value) return;
+
+  // 动态导入，确保只在客户端执行
+  const { downloadUnsealed } = await import(
+    "@yeez-tech/meta-encryptor/src/browser/downloadUnsealed.js"
+  );
+
+  await downloadUnsealed({
+    url: "http://example.com/encrypted.bin",
+    privateKey: "your-private-key-hex",
+    filename: "decrypted.bin",
+  });
+};
+</script>
+```
+
+### SSR 使用要点
+
+1. **必须使用动态导入**：`await import('@yeez-tech/meta-encryptor/src/browser/downloadUnsealed.js')`
+2. **在客户端事件中调用**：确保在用户交互事件（如点击）中执行，而不是在组件渲染时
+3. **推荐弹窗方案**：在弹窗的确认按钮中动态导入，最安全可靠
+4. **Next.js 使用 `'use client'`**：确保组件标记为客户端组件
+5. **Nuxt.js 使用 `onMounted`**：确保在客户端生命周期中调用
+6. **依赖兼容性**：`aes-js` 导入已修复，兼容 SSR 环境（Nuxt/Vite/Next.js）
+
+## 下载方案
+
+API 会自动选择最佳下载方案（按优先级）：
+
+1. **Service Worker**（优先）- 原生下载进度条，需要配置 Service Worker 文件
+2. **StreamSaver**（回退）- 需要引入 StreamSaver 库（可选）
+3. **Blob 下载**（最终回退）- 内存占用较大，但兼容性最好
+
+### 配置 Service Worker（可选，推荐）
+
+为了使用 Service Worker 方案（最佳体验），需要将 `sw-download.js` 复制到项目的 `public` 目录。
+
+#### Vite 配置示例
+
+```javascript
+// vite.config.js
+import { resolve } from "path";
+import { copyFileSync, existsSync, mkdirSync } from "fs";
+
+function copyServiceWorker() {
+  const swSource = resolve(
+    __dirname,
+    "node_modules/@yeez-tech/meta-encryptor/src/browser/sw-download.js"
+  );
+  const swDest = resolve(__dirname, "./public/sw-download.js");
+  const publicDir = resolve(__dirname, "./public");
+
+  if (existsSync(swSource)) {
+    if (!existsSync(publicDir)) {
+      mkdirSync(publicDir, { recursive: true });
+    }
+    copyFileSync(swSource, swDest);
+    console.log("[Vite] 已自动复制 Service Worker 文件到 public 目录");
+  }
+}
+
+// 在构建时复制
+export default {
+  // ... 其他配置
+  plugins: [
+    // ... 其他插件
+    {
+      name: "copy-service-worker",
+      buildStart() {
+        copyServiceWorker();
+      },
+    },
+  ],
+};
+```
+
+#### 手动复制
+
+```bash
+# 复制 Service Worker 文件到 public 目录
+cp node_modules/@yeez-tech/meta-encryptor/src/browser/sw-download.js public/sw-download.js
+```
+
+## 浏览器兼容性
+
+- ✅ Chrome/Edge 88+
+- ✅ Firefox 78+
+- ✅ Safari 14+
+- ✅ 支持 `fetch` API 和 `ReadableStream` 的现代浏览器
+
+## 常见问题
+
+### 1. Service Worker 注册失败
+
+如果看到 `[Download] 注册/使用同源 SW 失败`，请确保：
+
+- `sw-download.js` 已复制到 `public` 目录
+- 文件可以通过 HTTP 访问（如 `http://localhost:5173/sw-download.js`）
+- 浏览器支持 Service Worker（HTTPS 或 localhost）
+
+### 2. 下载到默认目录
+
+下载路径由浏览器控制，无法通过 API 配置。文件会保存到浏览器的默认下载目录。
+
+### 3. 大文件内存占用
+
+对于大文件，建议使用 Service Worker 方案（方案 1），它支持流式下载，内存占用最小。
+
+### 4. SSR 项目报错
+
+确保在客户端环境中使用，参考上面的 [SSR 支持](#ssr-支持) 部分。

--- a/src/browser/SealedHttpTailHeaderTransform.js
+++ b/src/browser/SealedHttpTailHeaderTransform.js
@@ -1,0 +1,121 @@
+// Reorder a sealed file whose header sits at tail into a header-first stream for UnsealerBrowser
+// Layout: [content][block_infos][header(64B)]
+// header format (little-endian): magic(8) | version(8) | block_number(8) | item_number(8) | data_hash(32)
+const HEADER_SIZE = 64;
+const BLOCK_INFO_SIZE = 32; // each block info entry size
+const DEFAULT_CHUNK_SIZE = 4 * 1024 * 1024; // 4MB
+
+function readUint64LE(buf, offset){
+  // buf: Uint8Array
+  const dv = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
+  if(dv.getBigUint64){
+    return Number(dv.getBigUint64(offset, true));
+  }
+  // Fallback manual
+  let val = 0;
+  for(let i=0;i<8;i++) val += buf[offset+i] * 2**(8*i);
+  return val;
+}
+
+async function fetchSealedHeaderFirst(url, opts={}){
+  const { log = console.log, chunked=false, chunkSize=DEFAULT_CHUNK_SIZE } = opts;
+  log('[TailHeader] HEAD 请求: ', url);
+  let totalSize = null;
+  try{
+    const headResp = await fetch(url, {method:'HEAD'});
+    if(headResp.ok){
+      const sizeHeader = headResp.headers.get('Content-Length');
+      if(sizeHeader) totalSize = Number(sizeHeader);
+    }
+  }catch(e){ /* ignore */ }
+  // helper: parse total from Content-Range
+  const parseTotal = (cr)=>{ if(!cr) return null; const m = /\/([0-9]+)$/.exec(cr); return m? Number(m[1]) : null; };
+  // If missing, try suffix range to retrieve header and total
+  let headerBuf = null;
+  if(totalSize == null){
+    log('[TailHeader] 无 Content-Length，使用后缀 Range 探测');
+    const tailProbe = await fetch(url, { headers:{ Range: `bytes=-${HEADER_SIZE}` }});
+    if(tailProbe.status === 206){
+      totalSize = parseTotal(tailProbe.headers.get('Content-Range'));
+      headerBuf = new Uint8Array(await tailProbe.arrayBuffer());
+    }
+  }
+  // If still unknown, do a 0-0 probe to get total then fetch tail header
+  if(totalSize == null){
+    const probe = await fetch(url, { headers:{ Range: 'bytes=0-0' }});
+    if(probe.status !== 206) throw new Error('无法获取 Content-Length');
+    totalSize = parseTotal(probe.headers.get('Content-Range'));
+  }
+  log('[TailHeader] totalSize =', totalSize);
+  if(!Number.isFinite(totalSize) || totalSize < HEADER_SIZE) throw new Error('文件大小异常');
+
+  let headerStart = totalSize - HEADER_SIZE;
+  if(!headerBuf){
+    log('[TailHeader] 读取尾部 header range=', headerStart, '-', totalSize-1);
+    const headerResp = await fetch(url, { headers:{ Range: `bytes=${headerStart}-${totalSize-1}` }});
+    if(!(headerResp.status === 206 || headerResp.status === 200)) throw new Error('获取尾部 header 失败: HTTP '+headerResp.status);
+    headerBuf = new Uint8Array(await headerResp.arrayBuffer());
+  }
+  if(headerBuf.length !== HEADER_SIZE) throw new Error('尾部 header 长度不符');
+  const blockNumber = readUint64LE(headerBuf, 16);
+  const contentSize = totalSize - HEADER_SIZE - BLOCK_INFO_SIZE * blockNumber;
+  log('[TailHeader] blockNumber=', blockNumber, 'contentSize=', contentSize);
+  if(contentSize <= 0) throw new Error('计算得到 contentSize <= 0');
+
+  if(!chunked){
+    const contentEnd = contentSize - 1;
+    log('[TailHeader] 单次获取内容区 range=0-', contentEnd);
+    const contentResp = await fetch(url, { headers:{ Range: `bytes=0-${contentEnd}` }});
+    if(!(contentResp.status === 206 || contentResp.status === 200)) throw new Error('获取内容区失败: HTTP '+contentResp.status);
+    if(!contentResp.body) throw new Error('内容区无 body');
+    const reader = contentResp.body.getReader();
+    let fetchedBytes = 0;
+    const combinedStream = new ReadableStream({
+      async start(controller){ controller.enqueue(headerBuf); },
+      async pull(controller){
+        const {done, value} = await reader.read();
+        if(done){ log('[TailHeader] 内容区读取完成 fetchedBytes=', fetchedBytes); controller.close(); return; }
+        fetchedBytes += value.length;
+        if(fetchedBytes % (16*1024*1024) < value.length){ // 每 ~16MB 打点
+          log('[TailHeader] 进度 fetched=', fetchedBytes, '/', contentSize);
+        }
+        controller.enqueue(value);
+      },
+      cancel(reason){ reader.cancel(reason); }
+    });
+    return new Response(combinedStream, { headers:{ 'Content-Type':'application/octet-stream' } });
+  }
+
+  // 分块模式
+  log('[TailHeader] 分块模式 chunkSize=', chunkSize);
+  let offset = 0;
+  const combinedStream = new ReadableStream({
+    headerSent:false,
+    async pull(controller){
+      if(!this.headerSent){ controller.enqueue(headerBuf); this.headerSent = true; return; }
+      if(offset >= contentSize){ controller.close(); return; }
+      const end = Math.min(offset + chunkSize - 1, contentSize - 1);
+      const rangeHeader = `bytes=${offset}-${end}`;
+      log('[TailHeader] 请求分块 range=', rangeHeader);
+      const partResp = await fetch(url, { headers:{ Range: rangeHeader }});
+      if(!(partResp.status === 206 || partResp.status === 200)) throw new Error('分块获取失败 HTTP '+partResp.status);
+      const partBuf = new Uint8Array(await partResp.arrayBuffer());
+      controller.enqueue(partBuf);
+      offset = end + 1;
+      if(offset % (16*1024*1024) < partBuf.length){
+        log('[TailHeader] 进度 offset=', offset, '/', contentSize);
+      }
+    }
+  });
+  return new Response(combinedStream, { headers:{ 'Content-Type':'application/octet-stream' } });
+}
+
+export async function prepareSealedResponse(url, opts={}){
+  try{
+    return await fetchSealedHeaderFirst(url, opts);
+  }catch(e){
+    const { log = console.log } = opts;
+    log('[TailHeader] 回退直接 fetch:', e.message);
+    return await fetch(url, { cache:'no-store' });
+  }
+}

--- a/src/browser/UnsealDownloader.vue
+++ b/src/browser/UnsealDownloader.vue
@@ -218,35 +218,48 @@ async function withNativeDownloadWriter(filename, expectedSize) {
   // 方案1: Service Worker（完全按照demo的实现）
   if ('serviceWorker' in navigator) {
     try {
-      // 尝试多个可能的路径
-      // 1. 如果用户将sw-download.js放到public目录（最常见）
-      // 2. 如果构建工具自动复制了（通过vite.config.js配置）
-      // 3. demo路径（兼容demo）
-      const swPaths = [
-        '/sw-download.js',  // 最常见：放到public根目录
-        '/example/browser/sw-download.js',  // demo路径（兼容demo）
-      ]
-      
+      // 先检查是否已经有注册的 Service Worker，避免重复注册导致正在进行的下载中断
       let reg = null
-      let swPath = null
       let scope = '/'
       
-      // 尝试注册Service Worker（按优先级尝试）
-      for (const pathStr of swPaths) {
-        try {
-          scope = pathStr.replace(/\/[^/]*$/, '/') || '/'
-          reg = await navigator.serviceWorker.register(pathStr, { scope })
-          swPath = pathStr
-          log(`[Download] 注册 Service Worker: ${pathStr}, scope: ${scope}`)
-          break  // 成功就退出
-        } catch (e) {
-          // 继续尝试下一个路径
-          continue
+      // 检查现有的注册
+      const existingRegistrations = await navigator.serviceWorker.getRegistrations()
+      for (const existingReg of existingRegistrations) {
+        // 检查是否是我们需要的 Service Worker（通过 scope 判断）
+        if (existingReg.scope === '/' || existingReg.scope.startsWith('/')) {
+          reg = existingReg
+          scope = existingReg.scope
+          log(`[Download] 复用已注册的 Service Worker: ${scope}`)
+          break
         }
       }
       
+      // 如果没有找到已注册的，才进行注册
       if (!reg) {
-        throw new Error('无法注册 Service Worker，所有路径都失败')
+        // 尝试多个可能的路径
+        // 1. 如果用户将sw-download.js放到public目录（最常见）
+        // 2. 如果构建工具自动复制了（通过vite.config.js配置）
+        // 3. demo路径（兼容demo）
+        const swPaths = [
+          '/sw-download.js',  // 最常见：放到public根目录
+          '/example/browser/sw-download.js',  // demo路径（兼容demo）
+        ]
+        
+        for (const pathStr of swPaths) {
+          try {
+            scope = pathStr.replace(/\/[^/]*$/, '/') || '/'
+            reg = await navigator.serviceWorker.register(pathStr, { scope })
+            log(`[Download] 注册 Service Worker: ${pathStr}, scope: ${scope}`)
+            break  // 成功就退出
+          } catch (e) {
+            // 继续尝试下一个路径
+            continue
+          }
+        }
+        
+        if (!reg) {
+          throw new Error('无法注册 Service Worker，所有路径都失败')
+        }
       }
       
       // Wait for SW to be ready and controlling this page
@@ -301,19 +314,57 @@ async function withNativeDownloadWriter(filename, expectedSize) {
       // Service Worker支持 /download/unsealed 或 endsWith('/download/unsealed')
       const downloadUrl = `/download/unsealed?id=${encodeURIComponent(id)}`
       
-      // Trigger native download in a new tab to keep current page streaming chunks
-      const w = window.open(downloadUrl, '_blank')
-      if (!w) {
-        // Fallback if popup blocked: temporary anchor without download attribute (navigation)
-        const a = document.createElement('a')
-        a.href = downloadUrl
-        a.target = '_blank'
-        document.body.appendChild(a)
-        a.click()
-        a.remove()
+      // 使用隐藏的 iframe 触发下载，避免新标签页闪屏
+      // Service Worker 会拦截请求并返回下载响应，iframe 仅用于触发请求
+      try {
+        const iframe = document.createElement('iframe')
+        iframe.style.cssText = 'position:absolute;width:0;height:0;border:none;opacity:0;pointer-events:none;'
+        document.body.appendChild(iframe)
+        
+        let iframeRemoved = false
+        const removeIframe = () => {
+          if (!iframeRemoved && iframe.parentNode) {
+            document.body.removeChild(iframe)
+            iframeRemoved = true
+          }
+        }
+        
+        // 监听 load 事件，加载完成后移除 iframe
+        // Service Worker 拦截后，iframe 会快速加载完成，此时下载已开始
+        iframe.onload = () => {
+          setTimeout(() => {
+            removeIframe()
+          }, 100) // 短暂延迟确保下载已触发
+        }
+        
+        // 设置超时，防止 iframe 加载失败时永远不清理
+        setTimeout(() => {
+          if (!iframeRemoved) {
+            removeIframe()
+          }
+        }, 5000)
+        
+        iframe.src = downloadUrl
+      } catch (e) {
+        // iframe 失败，回退到 window.open
+        try {
+          const w = window.open(downloadUrl, '_blank')
+          if (!w) {
+            // Fallback if popup blocked: temporary anchor without download attribute (navigation)
+            const a = document.createElement('a')
+            a.href = downloadUrl
+            a.target = '_blank'
+            document.body.appendChild(a)
+            a.click()
+            a.remove()
+          }
+        } catch (e2) {
+          // 如果所有方法都失败，抛出错误
+          throw new Error(`无法触发下载: ${e2.message}`)
+        }
       }
       
-      log(`[Download] 使用同源 SW 原生下载，size=${size ?? '未知'}`)
+      log(`[Download] 使用同源 SW 原生下载（隐藏 iframe，减少闪屏），size=${size ?? '未知'}`)
       return {
         async write(u8) {
           // Always send a copy so the original (e.g., reusable batch buffer) is not detached

--- a/src/browser/UnsealDownloader.vue
+++ b/src/browser/UnsealDownloader.vue
@@ -1,0 +1,508 @@
+<template>
+  <div class="unseal-downloader">
+    <slot
+      :download="download"
+      :isDownloading="isDownloading"
+      :progress="progress"
+      :error="error"
+      :status="status"
+    >
+      <button
+        :disabled="isDownloading || !canDownload"
+        @click="download"
+        class="download-btn"
+      >
+        {{ isDownloading ? '下载中...' : '下载并解密' }}
+      </button>
+      <div v-if="progress" class="progress-info">
+        <div>总块数: {{ progress.total }}</div>
+        <div>已处理: {{ progress.processed }}</div>
+        <div>已读: {{ formatBytes(progress.readBytes) }}</div>
+        <div>已写: {{ formatBytes(progress.writeBytes) }}</div>
+      </div>
+      <div v-if="error" class="error">{{ error }}</div>
+    </slot>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+import { unsealStream } from './UnsealerBrowser.js'
+import { prepareSealedResponse } from './SealedHttpTailHeaderTransform.js'
+
+const props = defineProps({
+  // 加密文件URL
+  url: {
+    type: String,
+    required: true
+  },
+  // 私钥（hex格式）
+  privateKey: {
+    type: String,
+    required: true
+  },
+  // 下载文件名
+  filename: {
+    type: String,
+    default: 'unsealed.bin'
+  },
+  // 是否启用分块模式
+  chunked: {
+    type: Boolean,
+    default: false
+  },
+  // 日志回调
+  onLog: {
+    type: Function,
+    default: null
+  },
+})
+
+const emit = defineEmits(['progress', 'success', 'error', 'start', 'complete'])
+
+const isDownloading = ref(false)
+const progress = ref(null)
+const error = ref(null)
+const status = ref('idle') // idle, downloading, success, error
+
+const canDownload = computed(() => {
+  return props.url && props.privateKey && !isDownloading.value
+})
+
+const log = (message) => {
+  if (props.onLog) {
+    props.onLog(message)
+  } else {
+    console.log(`[UnsealDownloader] ${message}`)
+  }
+}
+
+const formatBytes = (bytes) => {
+  if (!bytes) return '0 B'
+  const k = 1024
+  const sizes = ['B', 'KB', 'MB', 'GB']
+  const i = Math.floor(Math.log(bytes) / Math.log(k))
+  return Math.round(bytes / Math.pow(k, i) * 100) / 100 + ' ' + sizes[i]
+}
+
+
+// Same constants as in SealedHttpTailHeaderTransform
+const HEADER_SIZE = 64
+const BLOCK_INFO_SIZE = 32
+function readUint64LE(u8, off) {
+  const dv = new DataView(u8.buffer, u8.byteOffset, u8.byteLength)
+  const lo = dv.getUint32(off, true)
+  const hi = dv.getUint32(off + 4, true)
+  return hi * 0x100000000 + lo
+}
+
+// Inspect sealed file by HEAD + Range(tail) to compute contentSize (plaintext total bytes)
+async function inspectSealed(url) {
+  // Prefer HEAD to get total size
+  let totalSize = null
+  try {
+    const head = await fetch(url, { method: 'HEAD', cache: 'no-store' })
+    if (head.ok) {
+      const lenStr = head.headers.get('Content-Length')
+      if (lenStr) totalSize = Number(lenStr)
+    }
+  } catch (e) {
+    /* ignore */
+  }
+  // Helper: parse total from Content-Range: bytes start-end/total
+  const parseTotal = (cr) => {
+    if (!cr) return null
+    const m = /\/([0-9]+)$/.exec(cr)
+    return m ? Number(m[1]) : null
+  }
+  // Try to get tail header and total via suffix range
+  let headerBuf = null
+  if (totalSize == null) {
+    try {
+      const tail = await fetch(url, {
+        headers: { Range: `bytes=-${HEADER_SIZE}` },
+        cache: 'no-store'
+      })
+      if (tail.status === 206) {
+        const cr = tail.headers.get('Content-Range')
+        totalSize = parseTotal(cr)
+        headerBuf = new Uint8Array(await tail.arrayBuffer())
+      }
+    } catch (e) {
+      /* ignore */
+    }
+  }
+  // If still no total, try 0-0 probe then a tail fetch
+  if (totalSize == null) {
+    try {
+      const lr = await fetch(url, {
+        headers: { Range: 'bytes=0-0' },
+        cache: 'no-store'
+      })
+      if (lr.status === 206) {
+        totalSize = parseTotal(lr.headers.get('Content-Range'))
+      }
+    } catch (e) {
+      /* ignore */
+    }
+  }
+  if (totalSize == null) {
+    return { totalSize: null, blockNumber: null, contentSize: null }
+  }
+  if (!Number.isFinite(totalSize) || totalSize < HEADER_SIZE) throw new Error('文件大小异常')
+  // Ensure we have header bytes
+  if (!headerBuf) {
+    const start = totalSize - HEADER_SIZE
+    const tail = await fetch(url, {
+      headers: { Range: `bytes=${start}-${totalSize - 1}` },
+      cache: 'no-store'
+    })
+    if (!(tail.status === 206 || tail.status === 200))
+      throw new Error('Range 读取尾部 header 失败: ' + tail.status)
+    headerBuf = new Uint8Array(await tail.arrayBuffer())
+  }
+  if (headerBuf.length !== HEADER_SIZE) {
+    return { totalSize, blockNumber: null, contentSize: null }
+  }
+  const blockNumber = readUint64LE(headerBuf, 16)
+  const contentSize = totalSize - HEADER_SIZE - BLOCK_INFO_SIZE * blockNumber
+  if (contentSize <= 0) {
+    return { totalSize, blockNumber, contentSize: null }
+  }
+  return { totalSize, blockNumber, contentSize }
+}
+
+// 直接从demo复制的函数，保持完全一致
+async function withFileWriter(defaultName = 'unsealed.bin') {
+  // Prefer File System Access API when available
+  if (window.showSaveFilePicker) {
+    const handle = await window.showSaveFilePicker({
+      suggestedName: defaultName,
+      types: [{ description: 'Binary', accept: { 'application/octet-stream': ['.bin'] } }]
+    })
+    const writable = await handle.createWritable()
+    return {
+      async write(u8) {
+        await writable.write(u8)
+      },
+      async close() {
+        await writable.close()
+      }
+    }
+  }
+  // Fallback: accumulate to blob and trigger download at end
+  const chunks = []
+  return {
+    async write(u8) {
+      chunks.push(new Uint8Array(u8))
+    },
+    async close() {
+      const total = chunks.reduce((a, b) => a + b.length, 0)
+      const merged = new Uint8Array(total)
+      let o = 0
+      for (const c of chunks) {
+        merged.set(c, o)
+        o += c.length
+      }
+      const blob = new Blob([merged])
+      const a = document.createElement('a')
+      a.href = URL.createObjectURL(blob)
+      a.download = defaultName
+      a.click()
+    }
+  }
+}
+
+// 下载写入器：完全按照demo的实现，自动尝试Service Worker，失败则回退
+async function withNativeDownloadWriter(filename, expectedSize) {
+  // 方案1: Service Worker（完全按照demo的实现）
+  if ('serviceWorker' in navigator) {
+    try {
+      // 尝试多个可能的路径
+      // 1. 如果用户将sw-download.js放到public目录（最常见）
+      // 2. 如果构建工具自动复制了（通过vite.config.js配置）
+      // 3. demo路径（兼容demo）
+      const swPaths = [
+        '/sw-download.js',  // 最常见：放到public根目录
+        '/example/browser/sw-download.js',  // demo路径（兼容demo）
+      ]
+      
+      let reg = null
+      let swPath = null
+      let scope = '/'
+      
+      // 尝试注册Service Worker（按优先级尝试）
+      for (const pathStr of swPaths) {
+        try {
+          scope = pathStr.replace(/\/[^/]*$/, '/') || '/'
+          reg = await navigator.serviceWorker.register(pathStr, { scope })
+          swPath = pathStr
+          log(`[Download] 注册 Service Worker: ${pathStr}, scope: ${scope}`)
+          break  // 成功就退出
+        } catch (e) {
+          // 继续尝试下一个路径
+          continue
+        }
+      }
+      
+      if (!reg) {
+        throw new Error('无法注册 Service Worker，所有路径都失败')
+      }
+      
+      // Wait for SW to be ready and controlling this page
+      await navigator.serviceWorker.ready
+      
+      async function ensureController() {
+        if (navigator.serviceWorker.controller) return navigator.serviceWorker.controller
+        // try to message active worker directly
+        if (reg.active) return reg.active
+        await new Promise((resolve) => {
+          const to = setTimeout(resolve, 1500)
+          navigator.serviceWorker.addEventListener(
+            'controllerchange',
+            () => {
+              clearTimeout(to)
+              resolve()
+            },
+            { once: true }
+          )
+        })
+        return navigator.serviceWorker.controller || reg.active || null
+      }
+      const controller = await ensureController()
+      if (!controller) {
+        throw new Error('Service Worker 未接管此页面')
+      }
+
+      const id = Math.random().toString(36).slice(2)
+      const ch = new MessageChannel()
+      const size =
+        typeof expectedSize === 'number' && isFinite(expectedSize) ? expectedSize : undefined
+      
+      // Post to the active/controller SW
+      let portReady = false
+      const ackPromise = new Promise((resolve) => {
+        const to = setTimeout(resolve, 800)
+        ch.port1.onmessage = (ev) => {
+          if (ev.data && ev.data.type === 'ready') {
+            portReady = true
+            clearTimeout(to)
+            resolve()
+          }
+        }
+      })
+      ;(reg.active || controller).postMessage(
+        { type: 'DOWNLOAD_PORT', id, name: filename, size },
+        [ch.port2]
+      )
+      await ackPromise
+
+      // 使用下载路径（Service Worker会拦截这个路径）
+      // Service Worker支持 /download/unsealed 或 endsWith('/download/unsealed')
+      const downloadUrl = `/download/unsealed?id=${encodeURIComponent(id)}`
+      
+      // Trigger native download in a new tab to keep current page streaming chunks
+      const w = window.open(downloadUrl, '_blank')
+      if (!w) {
+        // Fallback if popup blocked: temporary anchor without download attribute (navigation)
+        const a = document.createElement('a')
+        a.href = downloadUrl
+        a.target = '_blank'
+        document.body.appendChild(a)
+        a.click()
+        a.remove()
+      }
+      
+      log(`[Download] 使用同源 SW 原生下载，size=${size ?? '未知'}`)
+      return {
+        async write(u8) {
+          // Always send a copy so the original (e.g., reusable batch buffer) is not detached
+          const copy =
+            u8 && u8.byteLength ? (u8.slice ? u8.slice() : new Uint8Array(u8)) : new Uint8Array()
+          ch.port1.postMessage({ type: 'chunk', data: copy }, [copy.buffer])
+        },
+        async close() {
+          ch.port1.postMessage({ type: 'end' })
+          ch.port1.close()
+        }
+      }
+    } catch (e) {
+      log('[Download] 注册/使用同源 SW 失败: ' + e.message)
+    }
+  }
+  
+  // 方案2: StreamSaver（如果可用，支持原生下载进度条）
+  if (window.streamSaver && typeof window.streamSaver.createWriteStream === 'function') {
+    try {
+      const fileStream = window.streamSaver.createWriteStream(filename, { size: expectedSize })
+      const writer = fileStream.getWriter()
+      log(`[Download] 使用 StreamSaver 原生下载，size=${expectedSize ?? '未知'}`)
+      return {
+        async write(u8) {
+          await writer.write(u8)
+        },
+        async close() {
+          await writer.close()
+        }
+      }
+    } catch (e) {
+      log('[Download] StreamSaver 失败，回退: ' + e.message)
+    }
+  }
+  log('[Download] 回退到 File System Access/Blob')
+  return withFileWriter(filename)
+}
+
+// 主下载函数
+async function download() {
+  if (!canDownload.value) {
+    return
+  }
+
+  isDownloading.value = true
+  error.value = null
+  progress.value = null
+  status.value = 'downloading'
+  emit('start')
+
+  try {
+    const url = props.url.trim()
+    const priv = props.privateKey.trim()
+
+    if (!url || !priv) {
+      throw new Error('请提供 URL 和私钥')
+    }
+
+    log('开始获取加密文件流...')
+
+    // 检查文件并获取元数据
+    const meta = await inspectSealed(url)
+    const expectedPlainBytes = meta.contentSize || undefined
+
+    if (expectedPlainBytes) {
+      log(`明文总大小(估算)=${expectedPlainBytes} 字节`)
+    } else {
+      log('未能获取明文总大小：以未知大小模式开始下载')
+    }
+
+    // 准备响应流
+    const resp = await prepareSealedResponse(url, {
+      log,
+      chunked: props.chunked
+    })
+
+    if (!resp.ok) {
+      throw new Error('HTTP 状态: ' + resp.status)
+    }
+
+    log('已连接，开始解密并写入文件...')
+
+    // 创建下载写入器（直接使用demo的实现，自动选择最佳方案）
+    const writer = await withNativeDownloadWriter(props.filename, expectedPlainBytes)
+
+    // 批量写入缓冲区
+    const BATCH_SIZE = 512 * 1024 // 512KB
+    let batch = new Uint8Array(BATCH_SIZE)
+    let batchLen = 0
+
+    // 流式解密并保存
+    await unsealStream(resp, {
+      privateKeyHex: priv,
+      onChunk: async (plain) => {
+        const len = plain?.length || 0
+        if (len === 0) return
+
+        // 批量写入
+        let off = 0
+        while (off < len) {
+          const can = Math.min(BATCH_SIZE - batchLen, len - off)
+          batch.set(plain.subarray(off, off + can), batchLen)
+          batchLen += can
+          off += can
+          if (batchLen === BATCH_SIZE) {
+            await writer.write(batch)
+            batchLen = 0
+          }
+        }
+      },
+      progressHandler: (total, processed, readBytes, writeBytes) => {
+        progress.value = {
+          total,
+          processed,
+          readBytes,
+          writeBytes
+        }
+        emit('progress', progress.value)
+      }
+    })
+
+    // 刷新剩余批次
+    if (batchLen > 0) {
+      await writer.write(batch.subarray(0, batchLen))
+    }
+
+    await writer.close()
+
+    status.value = 'success'
+    emit('success', { filename: props.filename })
+    log('下载并解密完成')
+  } catch (e) {
+    error.value = e.message
+    status.value = 'error'
+    emit('error', e)
+    log('下载失败: ' + e.message)
+  } finally {
+    isDownloading.value = false
+    emit('complete', { status: status.value, error: error.value })
+  }
+}
+
+defineExpose({
+  download,
+  isDownloading,
+  progress,
+  error,
+  status
+})
+</script>
+
+<style scoped>
+.unseal-downloader {
+  display: inline-block;
+}
+
+.download-btn {
+  padding: 8px 16px;
+  font-size: 14px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background: #fff;
+  cursor: pointer;
+}
+
+.download-btn:hover:not(:disabled) {
+  background: #f5f5f5;
+}
+
+.download-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.progress-info {
+  margin-top: 8px;
+  font-size: 12px;
+  color: #666;
+}
+
+.progress-info > div {
+  margin: 4px 0;
+}
+
+.error {
+  margin-top: 8px;
+  color: #f56c6c;
+  font-size: 12px;
+}
+</style>
+

--- a/src/browser/UnsealerBrowser.js
+++ b/src/browser/UnsealerBrowser.js
@@ -1,9 +1,7 @@
 // 使用浏览器兼容版本的 header_util，避免 bytebuffer 依赖问题
 import { ntpackage2batch, fromNtInput } from './header_util.browser.js';
 import { HeaderSize, MagicNum, CurrentBlockFileVersion } from '../limits.js';
-// SSR兼容：BrowserCrypto 在不同构建环境下导出方式不同
-import * as BrowserCryptoModule from './ypccrypto.browser.js';
-const BrowserCrypto = BrowserCryptoModule.default || BrowserCryptoModule.BrowserCrypto || BrowserCryptoModule;
+import { BrowserCrypto } from './ypccrypto.browser.js';
 
 // SSR兼容：将 MagicNum 转换为 Uint8Array（避免 Buffer 依赖）
 const MAGIC_NUM_BYTES = (() => {

--- a/src/browser/UnsealerBrowser.js
+++ b/src/browser/UnsealerBrowser.js
@@ -1,0 +1,149 @@
+import { ntpackage2batch, fromNtInput } from '../header_util.js';
+import { HeaderSize, MagicNum, CurrentBlockFileVersion } from '../limits.js';
+import BrowserCrypto from './ypccrypto.browser.js';
+
+// Incremental parser working on Uint8Array chunks.
+export class UnsealerBrowser {
+  constructor({ privateKeyHex, progressHandler } = {}) {
+    this.accumulated = new Uint8Array(0);
+    this.isHeaderReady = false;
+    this.header = null;
+    this.privateKeyHex = privateKeyHex;
+    this.progressHandler = progressHandler;
+    this.readItemCount = 0;
+    this.processedBytes = 0;
+    this.writeBytes = 0;
+  // omit running hash in browser sample to avoid Node Buffer dependency
+    this.totalItems = 0;
+    this.finished = false;
+  }
+
+  _append(chunk){
+    const a = new Uint8Array(this.accumulated.length + chunk.length);
+    a.set(this.accumulated,0); a.set(chunk, this.accumulated.length);
+    this.accumulated = a;
+  }
+
+  async _tryParseHeader(){
+    if(this.isHeaderReady) return;
+    if(this.accumulated.length < HeaderSize) return;
+    const headerBytes = this.accumulated.slice(0, HeaderSize);
+    const dv = new DataView(headerBytes.buffer, headerBytes.byteOffset, headerBytes.byteLength);
+    const readUint64LE = (off)=>{ const lo = dv.getUint32(off, true); const hi = dv.getUint32(off+4, true); return hi * 0x100000000 + lo; };
+    const version_number = readUint64LE(8);
+    if(version_number !== CurrentBlockFileVersion){
+      throw new Error('Unsupported version: '+version_number);
+    }
+    const magic = headerBytes.slice(0,8);
+    const magicBuf = Buffer.from(magic);
+    if(!magicBuf.equals(MagicNum)){
+      throw new Error('Magic number mismatch');
+    }
+    const item_number = readUint64LE(24);
+    this.totalItems = item_number;
+    this.accumulated = this.accumulated.slice(HeaderSize);
+    this.isHeaderReady = true;
+  }
+
+  async _extractOne(){
+    if(!this.isHeaderReady) return null;
+    if(this.accumulated.length < 8) return null;
+  // length prefix (little-endian uint64)
+  const dv = new DataView(this.accumulated.buffer, this.accumulated.byteOffset, this.accumulated.byteLength);
+  const lo = dv.getUint32(0, true); const hi = dv.getUint32(4, true);
+  const itemSize = hi * 0x100000000 + lo;
+    if(this.accumulated.length < 8 + itemSize) return null;
+    const cipher = this.accumulated.slice(8, 8 + itemSize);
+    this.accumulated = this.accumulated.slice(8 + itemSize);
+    this.processedBytes += (8 + itemSize);
+    // decrypt
+    let msg = await BrowserCrypto.decryptMessage(this.privateKeyHex, cipher);
+    if(!msg || msg.length < 12){
+      console.warn('Decrypted msg too short:', msg?.length || 0);
+      return [];
+    }
+    // If header doesn't match expected package id, try ASCII-hex fallback
+    const isPkgId = (m)=> m[0]===0xd8 && m[1]===0xe8 && m[2]===0xc4 && m[3]===0x82; // 0x82c4e8d8 LE
+    if(!isPkgId(msg)){
+      const looksAsciiHex = (m)=>{
+        const n = Math.min(m.length, 32);
+        for(let i=0;i<n;i++){
+          const c=m[i];
+          const isHex=(c>=0x30&&c<=0x39)||(c>=0x41&&c<=0x46)||(c>=0x61&&c<=0x66);
+          if(!isHex) return false;
+        }
+        return (m.length % 2)===0;
+      };
+      if(looksAsciiHex(msg)){
+        try{
+          const txt = new TextDecoder().decode(msg);
+          const clean = txt.replace(/[^0-9a-fA-F]/g,'');
+          const out = new Uint8Array(clean.length/2);
+          for(let i=0;i<out.length;i++) out[i]=parseInt(clean.substr(i*2,2),16);
+          if(out.length>=12 && isPkgId(out)){
+            console.warn('ASCII-hex decrypted payload detected; converted to bytes');
+            msg = out;
+          }
+        }catch(e){ /* ignore */ }
+      }
+    }
+    const batch = ntpackage2batch(msg);
+    let outputBuffers = [];
+    for(let i=0;i<batch.length;i++){
+      let it = batch[i];
+      // Normalize to Uint8Array for browser compatibility
+      if(it instanceof ArrayBuffer){
+        it = new Uint8Array(it);
+      } else if (ArrayBuffer.isView(it)) {
+        it = new Uint8Array(it.buffer, it.byteOffset, it.byteLength);
+      }
+      const b = fromNtInput(it);
+      outputBuffers.push(b);
+      this.writeBytes += b.length;
+  // omit rolling hash in browser demo
+    }
+    this.readItemCount += 1;
+    if(this.progressHandler){
+      this.progressHandler(this.totalItems, this.readItemCount, this.processedBytes, this.writeBytes);
+    }
+    if(this.readItemCount === this.totalItems){
+      this.finished = true;
+    }
+    return outputBuffers;
+  }
+
+  async pushChunk(chunk){
+    this._append(chunk instanceof Uint8Array ? chunk : new Uint8Array(chunk));
+    await this._tryParseHeader();
+    const results = [];
+    while(true){
+      const r = await this._extractOne();
+      if(!r) break;
+      results.push(...r);
+    }
+    return results; // array of Uint8Array plaintext segments
+  }
+
+  isDone(){return this.finished;}
+}
+
+export async function unsealStream(fetchResponse, {privateKeyHex, onChunk, progressHandler}){
+  const reader = fetchResponse.body.getReader();
+  const un = new UnsealerBrowser({privateKeyHex, progressHandler});
+  let all = [];
+  while(true){
+    const {done, value} = await reader.read();
+    if(done) break;
+    const outs = await un.pushChunk(value);
+    for (const o of outs){
+      if(onChunk){
+        // support async writer (e.g., streaming to file)
+        await onChunk(o);
+      }
+      all.push(o);
+    }
+  }
+  return all;
+}
+
+export default { UnsealerBrowser, unsealStream };

--- a/src/browser/browserCapabilities.js
+++ b/src/browser/browserCapabilities.js
@@ -1,0 +1,51 @@
+// 浏览器能力检测工具
+// 用于检测浏览器类型和 API 支持情况，帮助选择合适的下载方案
+
+export function detectBrowserCapabilities() {
+  const ua = navigator.userAgent.toLowerCase()
+  const isMobile = /android|iphone|ipad|ipod|blackberry|iemobile|opera mini/i.test(ua)
+  
+  // 检测浏览器类型
+  const browserInfo = {
+    isMobile,
+    isBaidu: /baiduboxapp|baidubrowser/i.test(ua),
+    isQQ: /mqqbrowser|qzone/i.test(ua),
+    isUC: /ucbrowser|ucweb/i.test(ua),
+    isQuark: /quark/i.test(ua),
+    isXiaomi: /miuibrowser/i.test(ua),
+    isWeChat: /micromessenger/i.test(ua),
+    isChrome: /chrome/i.test(ua) && !/edge|edg/i.test(ua),
+    isEdge: /edge|edg/i.test(ua),
+    isSafari: /safari/i.test(ua) && !/chrome|crios|fxios/i.test(ua),
+  }
+  
+  // 检测 API 支持
+  const capabilities = {
+    serviceWorker: 'serviceWorker' in navigator,
+    messageChannel: typeof MessageChannel !== 'undefined',
+    readableStream: typeof ReadableStream !== 'undefined',
+    streamSaver: typeof window !== 'undefined' && window.streamSaver && typeof window.streamSaver.createWriteStream === 'function',
+    fileSystemAccess: typeof window !== 'undefined' && 'showSaveFilePicker' in window,
+    blob: typeof Blob !== 'undefined' && typeof URL !== 'undefined' && 'createObjectURL' in URL,
+  }
+  
+  // 针对已知有问题的浏览器，禁用某些功能
+  // 这些浏览器对 Service Worker + MessageChannel + ReadableStream 的支持不完整
+  const shouldSkipServiceWorker = 
+    browserInfo.isBaidu || 
+    browserInfo.isQQ || 
+    browserInfo.isUC || 
+    browserInfo.isQuark || 
+    browserInfo.isXiaomi ||
+    (isMobile && !browserInfo.isChrome && !browserInfo.isEdge && !browserInfo.isSafari)
+  
+  return {
+    browserInfo,
+    capabilities: {
+      ...capabilities,
+      serviceWorker: capabilities.serviceWorker && !shouldSkipServiceWorker,
+    },
+    shouldSkipServiceWorker,
+  }
+}
+

--- a/src/browser/bytebuffer.browser.js
+++ b/src/browser/bytebuffer.browser.js
@@ -1,6 +1,0 @@
-// Browser wrapper for bytebuffer to provide default export and named LITTLE_ENDIAN
-import BBPkg from 'https://esm.sh/bytebuffer@5.0.1?target=es2020';
-const ByteBuffer = BBPkg.default || BBPkg;
-const LITTLE_ENDIAN = ByteBuffer.LITTLE_ENDIAN;
-export { LITTLE_ENDIAN };
-export default ByteBuffer;

--- a/src/browser/bytebuffer.browser.js
+++ b/src/browser/bytebuffer.browser.js
@@ -1,0 +1,6 @@
+// Browser wrapper for bytebuffer to provide default export and named LITTLE_ENDIAN
+import BBPkg from 'https://esm.sh/bytebuffer@5.0.1?target=es2020';
+const ByteBuffer = BBPkg.default || BBPkg;
+const LITTLE_ENDIAN = ByteBuffer.LITTLE_ENDIAN;
+export { LITTLE_ENDIAN };
+export default ByteBuffer;

--- a/src/browser/downloadUnsealed.js
+++ b/src/browser/downloadUnsealed.js
@@ -1,0 +1,299 @@
+// 命令式 API：下载并解密加密文件
+// 使用方式：
+// import { downloadUnsealed } from '@yeez-tech/meta-encryptor/src/browser/downloadUnsealed.js'
+// downloadUnsealed({ url: '...', privateKey: '...', filename: '...' })
+
+import { unsealStream } from './UnsealerBrowser.js'
+import { prepareSealedResponse } from './SealedHttpTailHeaderTransform.js'
+
+// 检查文件并获取元数据
+async function inspectSealed(url) {
+  const HEADER_SIZE = 64
+  const BLOCK_INFO_SIZE = 32
+  
+  try {
+    const headResp = await fetch(url, { method: 'HEAD' })
+    const totalSize = parseInt(headResp.headers.get('Content-Length') || '0', 10)
+    
+    if (totalSize < HEADER_SIZE) {
+      return { totalSize, blockNumber: null, contentSize: null }
+    }
+    
+    // 读取文件末尾的 header
+    const tailStart = Math.max(0, totalSize - HEADER_SIZE)
+    const tailResp = await fetch(url, {
+      headers: { Range: `bytes=${tailStart}-${totalSize - 1}` }
+    })
+    
+    if (!tailResp.ok) {
+      return { totalSize, blockNumber: null, contentSize: null }
+    }
+    
+    const headerBuf = new Uint8Array(await tailResp.arrayBuffer())
+    if (headerBuf.length !== HEADER_SIZE) {
+      return { totalSize, blockNumber: null, contentSize: null }
+    }
+    
+    // 解析 header 获取 blockNumber
+    const blockNumber = new DataView(headerBuf.buffer).getBigUint64(16, true)
+    const contentSize = totalSize - HEADER_SIZE - Number(blockNumber) * BLOCK_INFO_SIZE
+    
+    if (contentSize <= 0) {
+      return { totalSize, blockNumber: Number(blockNumber), contentSize: null }
+    }
+    
+    return { totalSize, blockNumber: Number(blockNumber), contentSize }
+  } catch (e) {
+    return { totalSize: 0, blockNumber: null, contentSize: null }
+  }
+}
+
+// 下载写入器：自动选择最佳方案
+async function withNativeDownloadWriter(filename, expectedSize, log) {
+  log = log || (() => {})
+  
+  // 方案1: Service Worker
+  if ('serviceWorker' in navigator) {
+    try {
+      const swPaths = [
+        '/sw-download.js',
+        '/example/browser/sw-download.js',
+      ]
+      
+      let reg = null
+      let scope = '/'
+      
+      for (const pathStr of swPaths) {
+        try {
+          scope = pathStr.replace(/\/[^/]*$/, '/') || '/'
+          reg = await navigator.serviceWorker.register(pathStr, { scope })
+          log(`[Download] 注册 Service Worker: ${pathStr}, scope: ${scope}`)
+          break
+        } catch (e) {
+          continue
+        }
+      }
+      
+      if (!reg) {
+        throw new Error('无法注册 Service Worker，所有路径都失败')
+      }
+      
+      await navigator.serviceWorker.ready
+      
+      async function ensureController() {
+        if (navigator.serviceWorker.controller) return navigator.serviceWorker.controller
+        if (reg.active) return reg.active
+        await new Promise((resolve) => {
+          const to = setTimeout(resolve, 1500)
+          navigator.serviceWorker.addEventListener(
+            'controllerchange',
+            () => {
+              clearTimeout(to)
+              resolve()
+            },
+            { once: true }
+          )
+        })
+        return navigator.serviceWorker.controller || reg.active || null
+      }
+      const controller = await ensureController()
+      if (!controller) {
+        throw new Error('Service Worker 未接管此页面')
+      }
+
+      const id = Math.random().toString(36).slice(2)
+      const ch = new MessageChannel()
+      const size = typeof expectedSize === 'number' && isFinite(expectedSize) ? expectedSize : undefined
+      
+      let portReady = false
+      const ackPromise = new Promise((resolve) => {
+        const to = setTimeout(resolve, 800)
+        ch.port1.onmessage = (ev) => {
+          if (ev.data && ev.data.type === 'ready') {
+            portReady = true
+            clearTimeout(to)
+            resolve()
+          }
+        }
+      })
+      ;(reg.active || controller).postMessage(
+        { type: 'DOWNLOAD_PORT', id, name: filename, size },
+        [ch.port2]
+      )
+      await ackPromise
+
+      const downloadUrl = `/download/unsealed?id=${encodeURIComponent(id)}`
+      const w = window.open(downloadUrl, '_blank')
+      if (!w) {
+        const a = document.createElement('a')
+        a.href = downloadUrl
+        a.target = '_blank'
+        document.body.appendChild(a)
+        a.click()
+        a.remove()
+      }
+      
+      log(`[Download] 使用同源 SW 原生下载，size=${size ?? '未知'}`)
+      return {
+        async write(u8) {
+          const copy = u8 && u8.byteLength ? (u8.slice ? u8.slice() : new Uint8Array(u8)) : new Uint8Array()
+          ch.port1.postMessage({ type: 'chunk', data: copy }, [copy.buffer])
+        },
+        async close() {
+          ch.port1.postMessage({ type: 'end' })
+          ch.port1.close()
+        }
+      }
+    } catch (e) {
+      log('[Download] 注册/使用同源 SW 失败: ' + e.message)
+    }
+  }
+  
+  // 方案2: StreamSaver
+  if (window.streamSaver && typeof window.streamSaver.createWriteStream === 'function') {
+    try {
+      const fileStream = window.streamSaver.createWriteStream(filename, { size: expectedSize })
+      const writer = fileStream.getWriter()
+      log(`[Download] 使用 StreamSaver 原生下载，size=${expectedSize ?? '未知'}`)
+      return {
+        async write(u8) {
+          await writer.write(u8)
+        },
+        async close() {
+          await writer.close()
+        }
+      }
+    } catch (e) {
+      log('[Download] StreamSaver 失败，回退: ' + e.message)
+    }
+  }
+  
+  // 方案3: Blob 下载
+  log('[Download] 回退到 Blob 下载')
+  const chunks = []
+  return {
+    async write(u8) {
+      chunks.push(u8)
+    },
+    async close() {
+      const blob = new Blob(chunks, { type: 'application/octet-stream' })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = filename
+      document.body.appendChild(a)
+      a.click()
+      document.body.removeChild(a)
+      URL.revokeObjectURL(url)
+    }
+  }
+}
+
+/**
+ * 下载并解密加密文件
+ * @param {Object} options 配置选项
+ * @param {string} options.url - 加密文件的 URL（支持 Range 请求）
+ * @param {string} options.privateKey - 私钥（hex 格式，64字节）
+ * @param {string} options.filename - 下载文件名
+ * @param {Function} [options.onLog] - 日志回调函数
+ * @param {Function} [options.onProgress] - 进度回调函数 (total, processed, readBytes, writeBytes) => {}
+ * @param {Function} [options.onSuccess] - 成功回调函数 (data) => {}
+ * @param {Function} [options.onError] - 错误回调函数 (error) => {}
+ * @returns {Promise<void>}
+ */
+export async function downloadUnsealed({
+  url,
+  privateKey,
+  filename,
+  onLog,
+  onProgress,
+  onSuccess,
+  onError
+}) {
+  const log = onLog || (() => {})
+  
+  try {
+    if (!url || !privateKey || !filename) {
+      throw new Error('请提供 URL、私钥和文件名')
+    }
+
+    log('开始获取加密文件流...')
+
+    // 检查文件并获取元数据
+    const meta = await inspectSealed(url)
+    const expectedPlainBytes = meta.contentSize || undefined
+
+    if (expectedPlainBytes) {
+      log(`明文总大小(估算)=${expectedPlainBytes} 字节`)
+    } else {
+      log('未能获取明文总大小：以未知大小模式开始下载')
+    }
+
+    // 准备响应流
+    const resp = await prepareSealedResponse(url, {
+      log,
+      chunked: false
+    })
+
+    if (!resp.ok) {
+      throw new Error('HTTP 状态: ' + resp.status)
+    }
+
+    log('已连接，开始解密并写入文件...')
+
+    // 创建下载写入器
+    const writer = await withNativeDownloadWriter(filename, expectedPlainBytes, log)
+
+    // 批量写入缓冲区
+    const BATCH_SIZE = 512 * 1024 // 512KB
+    let batch = new Uint8Array(BATCH_SIZE)
+    let batchLen = 0
+
+    // 流式解密并保存
+    await unsealStream(resp, {
+      privateKeyHex: privateKey.trim(),
+      onChunk: async (plain) => {
+        const len = plain?.length || 0
+        if (len === 0) return
+
+        // 批量写入
+        let off = 0
+        while (off < len) {
+          const can = Math.min(BATCH_SIZE - batchLen, len - off)
+          batch.set(plain.subarray(off, off + can), batchLen)
+          batchLen += can
+          off += can
+          if (batchLen === BATCH_SIZE) {
+            await writer.write(batch)
+            batchLen = 0
+          }
+        }
+      },
+      progressHandler: (total, processed, readBytes, writeBytes) => {
+        if (onProgress) {
+          onProgress(total, processed, readBytes, writeBytes)
+        }
+      }
+    })
+
+    // 写入剩余数据
+    if (batchLen > 0) {
+      await writer.write(batch.subarray(0, batchLen))
+    }
+
+    await writer.close()
+    log('下载完成')
+
+    if (onSuccess) {
+      onSuccess({ filename })
+    }
+  } catch (error) {
+    log('下载失败: ' + error.message)
+    if (onError) {
+      onError(error)
+    } else {
+      throw error
+    }
+  }
+}
+

--- a/src/browser/header_util.browser.js
+++ b/src/browser/header_util.browser.js
@@ -1,0 +1,84 @@
+// Browser-compatible header_util using Uint8Array + DataView
+// 完全使用原生浏览器 API，避免 bytebuffer 依赖和兼容性问题
+
+/**
+ * Read uint64 (little-endian) from Uint8Array at offset
+ */
+function readUint64LE(buffer, offset) {
+  // Ensure we have a proper buffer view
+  const buf = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
+  const dv = new DataView(buf.buffer, buf.byteOffset + offset, 8);
+  const lo = dv.getUint32(0, true);
+  const hi = dv.getUint32(4, true);
+  // Combine into number (safe for values < 2^53)
+  const value = Number(hi) * 0x100000000 + Number(lo);
+  return { toNumber: () => value, valueOf: () => value };
+}
+
+/**
+ * Write uint64 (little-endian) to Uint8Array at offset
+ */
+function writeUint64LE(buffer, offset, value) {
+  const dv = new DataView(buffer.buffer, buffer.byteOffset + offset, 8);
+  const lo = value & 0xffffffff;
+  const hi = Math.floor(value / 0x100000000);
+  dv.setUint32(0, lo, true);
+  dv.setUint32(4, hi, true);
+}
+
+/**
+ * Read uint32 (little-endian) from Uint8Array at offset
+ */
+function readUint32LE(buffer, offset) {
+  const dv = new DataView(buffer.buffer, buffer.byteOffset + offset, 4);
+  return dv.getUint32(0, true);
+}
+
+/**
+ * Write uint32 (little-endian) to Uint8Array at offset
+ */
+function writeUint32LE(buffer, offset, value) {
+  const dv = new DataView(buffer.buffer, buffer.byteOffset + offset, 4);
+  dv.setUint32(0, value, true);
+}
+
+/**
+ * Convert NT package to batch (browser version)
+ * @param {Uint8Array} pkg - Package bytes
+ * @returns {Uint8Array[]} - Array of batch item buffers
+ */
+export function ntpackage2batch(pkg) {
+  const batch = [];
+  let offset = 4; // Skip package id (4 bytes)
+  
+  // Read batch count (uint64)
+  const countObj = readUint64LE(pkg, offset);
+  const cnt = countObj.toNumber();
+  offset += 8;
+  
+  // Read each batch item
+  for (let i = 0; i < cnt; i++) {
+    // Read item length (uint64)
+    const lenObj = readUint64LE(pkg, offset);
+    const len = lenObj.toNumber();
+    offset += 8;
+    
+    // Extract item data
+    const item = pkg.slice(offset, offset + len);
+    batch.push(item);
+    offset += len;
+  }
+  
+  return batch;
+}
+
+/**
+ * Extract data from NT input (browser version)
+ * @param {Uint8Array} inputNt - NT input bytes
+ * @returns {Uint8Array} - Extracted data (skips first 12 bytes: 4-byte prefix + 8-byte size)
+ */
+export function fromNtInput(inputNt) {
+  let offset = 12; // Skip prefix (4) + size (8)
+  return inputNt.slice(offset, inputNt.length);
+}
+

--- a/src/browser/index.browser.js
+++ b/src/browser/index.browser.js
@@ -1,0 +1,2 @@
+export { BrowserCrypto } from './ypccrypto.browser.js';
+export { UnsealerBrowser, unsealStream } from './UnsealerBrowser.js';

--- a/src/browser/index.browser.js
+++ b/src/browser/index.browser.js
@@ -1,3 +1,4 @@
-export { BrowserCrypto } from './ypccrypto.browser.js';
+// 导出 BrowserCrypto 和 YPCCrypto（同一个对象，不同名称）
+export { BrowserCrypto, default as YPCCrypto } from './ypccrypto.browser.js';
 export { UnsealerBrowser, unsealStream } from './UnsealerBrowser.js';
 export { downloadUnsealed } from './downloadUnsealed.js';

--- a/src/browser/index.browser.js
+++ b/src/browser/index.browser.js
@@ -1,2 +1,3 @@
 export { BrowserCrypto } from './ypccrypto.browser.js';
 export { UnsealerBrowser, unsealStream } from './UnsealerBrowser.js';
+export { downloadUnsealed } from './downloadUnsealed.js';

--- a/src/browser/sw-download.js
+++ b/src/browser/sw-download.js
@@ -1,0 +1,140 @@
+// Same-origin Service Worker to stream decrypted data as a downloadable attachment
+// Frontend will post a MessagePort with an ID; SW responds to a fetch on /download/unsealed?id=ID
+// and pipes chunks received via MessagePort into the Response stream with proper headers.
+
+/* eslint-disable no-undef */
+const downloads = new Map(); // id -> { port, name, size }
+
+self.addEventListener("install", () => {
+  self.skipWaiting();
+});
+self.addEventListener("activate", (e) => {
+  e.waitUntil(self.clients.claim());
+});
+
+self.addEventListener("message", (event) => {
+  const data = event.data || {};
+  if (data.type === "DOWNLOAD_PORT" && event.ports && event.ports[0]) {
+    const { id, name, size } = data;
+    downloads.set(id, {
+      port: event.ports[0],
+      name: name || "download.bin",
+      size: size || null,
+    });
+    try {
+      event.ports[0].postMessage({ type: "ready", id });
+    } catch (e) {
+      // Ignore postMessage errors (port may already be closed)
+    }
+  }
+});
+
+function streamFromPort(meta) {
+  // 处理文件名编码：避免 ISO-8859-1 编码错误
+  // 对于包含非 ASCII 字符的文件名，需要特殊处理
+  const headers = new Headers();
+  headers.set("Content-Type", "application/octet-stream");
+
+  // 安全地设置 Content-Disposition header
+  // 检查文件名是否只包含可打印的 ASCII 字符（0x20-0x7E）和控制字符除外
+  // 避免使用控制字符 \x00-\x1F，因为文件名不应该包含这些
+  const isAscii = /^[\u0020-\u007E]*$/.test(meta.name);
+
+  if (isAscii) {
+    // 纯 ASCII 文件名，可以直接使用
+    try {
+      headers.set("Content-Disposition", `attachment; filename="${meta.name}"`);
+    } catch (e) {
+      // 如果仍然失败，使用 URL 编码
+      const encoded = encodeURIComponent(meta.name);
+      headers.set(
+        "Content-Disposition",
+        `attachment; filename*=UTF-8''${encoded}`
+      );
+    }
+  } else {
+    // 包含非 ASCII 字符，使用 RFC 5987 编码格式
+    // 提供两个版本：ASCII 安全版本和 UTF-8 编码版本
+    // 将非可打印 ASCII 字符替换为下划线
+    const safeFilename = meta.name.replace(/[^\u0020-\u007E]/g, "_");
+    const encodedFilename = encodeURIComponent(meta.name);
+    try {
+      headers.set(
+        "Content-Disposition",
+        `attachment; filename="${safeFilename}"; filename*=UTF-8''${encodedFilename}`
+      );
+    } catch (e) {
+      // 如果设置失败，只使用 UTF-8 编码版本
+      headers.set(
+        "Content-Disposition",
+        `attachment; filename*=UTF-8''${encodedFilename}`
+      );
+    }
+  }
+
+  if (meta.size && Number.isFinite(meta.size)) {
+    headers.set("Content-Length", String(meta.size));
+  }
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        const port = meta.port;
+        port.onmessage = (ev) => {
+          const msg = ev.data || {};
+          if (msg.type === "chunk") {
+            let src = msg.data;
+            if (src && !(src instanceof Uint8Array) && src.buffer) {
+              src = new Uint8Array(
+                src.buffer,
+                src.byteOffset || 0,
+                src.byteLength || src.length || 0
+              );
+            }
+            // Create a fresh copy to ensure the buffer is not detached by transfer
+            const chunk =
+              src && src.byteLength ? new Uint8Array(src) : new Uint8Array();
+            controller.enqueue(chunk);
+          } else if (msg.type === "end") {
+            controller.close();
+            port.close();
+          } else if (msg.type === "error") {
+            controller.error(new Error(msg.message || "download error"));
+            port.close();
+          }
+        };
+        try {
+          port.start && port.start();
+        } catch (e) {
+          // Ignore port start errors
+        }
+      },
+      cancel() {
+        try {
+          meta.port.postMessage({ type: "cancel" });
+        } catch (e) {
+          // Ignore cancel message errors (port may already be closed)
+        }
+      },
+    }),
+    { headers }
+  );
+}
+
+self.addEventListener("fetch", (event) => {
+  const url = new URL(event.request.url);
+  // 拦截下载路径（固定路径，不需要前缀）
+  if (
+    url.pathname === "/download/unsealed" ||
+    url.pathname.endsWith("/download/unsealed")
+  ) {
+    const id = url.searchParams.get("id");
+    const meta = id && downloads.get(id);
+    if (!meta) {
+      event.respondWith(new Response("download id not found", { status: 404 }));
+      return;
+    }
+    // one-shot, clean up after start
+    downloads.delete(id);
+    event.respondWith(streamFromPort(meta));
+  }
+});

--- a/src/browser/transferableSupport.js
+++ b/src/browser/transferableSupport.js
@@ -1,0 +1,77 @@
+// 检测浏览器对 Transferable Objects 的支持
+// 某些移动端浏览器（特别是基于旧版 Chromium 的）对 Transferable Objects 支持不完整
+
+let supportsTransferable = null;
+
+export function checkTransferableSupport() {
+  if (supportsTransferable !== null) {
+    return supportsTransferable;
+  }
+
+  try {
+    // 检测 MessageChannel 是否支持 Transferable Objects
+    const ch = new MessageChannel();
+    const testBuffer = new ArrayBuffer(8);
+    const view = new Uint8Array(testBuffer);
+    view[0] = 0x42; // 设置一个测试值
+
+    let received = false;
+    const testPromise = new Promise((resolve) => {
+      ch.port1.onmessage = (ev) => {
+        received = true;
+        // 如果 transfer 成功，原始 buffer 应该变成 detached (byteLength = 0)
+        // 但接收端应该能收到数据
+        if (ev.data && ev.data.buffer) {
+          const receivedView = new Uint8Array(ev.data.buffer);
+          resolve(receivedView[0] === 0x42);
+        } else {
+          resolve(false);
+        }
+      };
+      ch.port1.onerror = () => resolve(false);
+    });
+
+    // 发送测试数据，使用 transfer
+    ch.port2.postMessage({ data: testBuffer }, [testBuffer]);
+
+    // 检查原始 buffer 是否被 detached
+    const isDetached = testBuffer.byteLength === 0;
+
+    // 等待接收
+    return testPromise.then((receivedCorrectly) => {
+      supportsTransferable = isDetached && receivedCorrectly;
+      return supportsTransferable;
+    }).catch(() => {
+      supportsTransferable = false;
+      return false;
+    });
+  } catch (e) {
+    supportsTransferable = false;
+    return Promise.resolve(false);
+  }
+}
+
+// 同步检测（快速检测，可能不准确）
+export function supportsTransferableSync() {
+  if (supportsTransferable !== null) {
+    return supportsTransferable;
+  }
+
+  // 简单检测：检查 MessageChannel 和 ArrayBuffer 是否存在
+  if (typeof MessageChannel === 'undefined' || typeof ArrayBuffer === 'undefined') {
+    return false;
+  }
+
+  // 对于移动端浏览器，保守地假设可能不支持
+  const ua = navigator.userAgent.toLowerCase();
+  const isProblematicBrowser = 
+    /baiduboxapp|baidubrowser|mqqbrowser|ucbrowser|quark|miuibrowser/i.test(ua);
+
+  if (isProblematicBrowser) {
+    return false; // 保守地假设不支持
+  }
+
+  // 对于其他浏览器，假设支持（但实际使用时仍需要异步检测）
+  return true;
+}
+

--- a/src/browser/vite.config.example.js
+++ b/src/browser/vite.config.example.js
@@ -1,0 +1,31 @@
+// Vite 配置示例：自动复制 Service Worker 文件
+// 将以下代码添加到你的 vite.config.js 中
+
+import { defineConfig } from 'vite'
+import { resolve } from 'path'
+import { copyFileSync, existsSync, mkdirSync } from 'fs'
+
+// 自动从node_modules复制Service Worker文件到public目录
+function copyServiceWorker() {
+  // 从npm包中复制（生产环境）
+  const swSourceFromNpm = resolve(__dirname, 'node_modules/@yeez-tech/meta-encryptor/src/browser/sw-download.js')
+  const swDest = resolve(__dirname, './public/sw-download.js')
+  const publicDir = resolve(__dirname, './public')
+  
+  if (existsSync(swSourceFromNpm)) {
+    // 确保 public 目录存在
+    if (!existsSync(publicDir)) {
+      mkdirSync(publicDir, { recursive: true })
+    }
+    copyFileSync(swSourceFromNpm, swDest)
+    console.log('[Vite] 已自动复制 Service Worker 文件到 public 目录')
+  }
+}
+
+// 在导出配置前调用
+copyServiceWorker()
+
+export default defineConfig({
+  // 你的其他配置...
+})
+

--- a/src/browser/ypccrypto.browser.js
+++ b/src/browser/ypccrypto.browser.js
@@ -1,0 +1,122 @@
+// Browser implementation of ypccrypto decrypt logic using @noble/secp256k1 and WebCrypto
+// Derivation mimics aes-cmac based scheme from node version using pure JS AES-CMAC.
+import {getPublicKey, getSharedSecret} from '@noble/secp256k1';
+import AES from 'aes-js';
+
+// aes-cmac implementation (simplified) based on AES-128
+function aesCmac(key, message){
+  // Generate subkeys per RFC 4493
+  const aes = new AES.ModeOfOperation.ecb(key);
+  const blockSize = 16;
+  function leftShift(buf){
+    const out = new Uint8Array(buf.length);
+    let carry = 0;
+    for(let i=buf.length-1;i>=0;i--){
+      const val = buf[i];
+      out[i] = ((val<<1)&0xFF) | carry;
+      carry = (val & 0x80)?1:0;
+    }
+    return out;
+  }
+  const constRb = 0x87;
+  function xor16(a,b){const o=new Uint8Array(16);for(let i=0;i<16;i++)o[i]=a[i]^b[i];return o;}
+  let zeros = new Uint8Array(16);
+  let L = aes.encrypt(zeros);
+  L = new Uint8Array(L);
+  let K1 = leftShift(L);
+  if((L[0] & 0x80)!==0){K1[15] ^= constRb;}
+  let K2 = leftShift(K1);
+  if((K1[0] & 0x80)!==0){K2[15] ^= constRb;}
+  // Split message into 16 byte blocks
+  const m = new Uint8Array(message);
+  const n = Math.ceil(m.length / blockSize);
+  let flagComplete = m.length>0 && (m.length % blockSize === 0);
+  let lastBlock;
+  if(n===0){
+    flagComplete = false;
+    lastBlock = xor16(xor16(zeros,K2),new Uint8Array([0x80,...new Array(15).fill(0)]));
+  }else{
+    const startLast = (n-1)*blockSize;
+    let lb = m.slice(startLast, startLast+blockSize);
+    if(flagComplete){
+      lastBlock = xor16(lb,K1);
+    }else{
+      let pad = new Uint8Array(blockSize);
+      pad.set(lb); pad[lb.length]=0x80; // rest zeros
+      lastBlock = xor16(pad,K2);
+    }
+  }
+  let X = new Uint8Array(16);
+  for(let i=0;i<n-1;i++){
+    const block = m.slice(i*blockSize,(i+1)*blockSize);
+    X = aes.encrypt(xor16(X, block));
+    X = new Uint8Array(X);
+  }
+  let T = aes.encrypt(xor16(X,lastBlock));
+  return new Uint8Array(T);
+}
+
+const aadStr = 'tech.yeez.key.manager';
+const aad = new TextEncoder().encode(aadStr);
+function hexToBytes(hex){
+  const clean = hex.startsWith('0x')? hex.slice(2): hex;
+  const arr = new Uint8Array(clean.length/2);
+  for(let i=0;i<arr.length;i++){ arr[i] = parseInt(clean.substr(i*2,2),16); }
+  return arr;
+}
+const cmac_key = hexToBytes('7965657a2e746563682e7374626f7800');
+
+// emulate libsecp256k1 ecdh with custom hashfn by hashing compressed shared point (WebCrypto)
+async function sha256Bytes(u8){
+  const digest = await crypto.subtle.digest('SHA-256', u8);
+  return new Uint8Array(digest);
+}
+
+function generatePublicKeyFromPrivateKey(priv){
+  // Uncompressed (04 + x + y) then drop leading 0x04
+  const full = getPublicKey(priv, false); // 65 bytes
+  return full.slice(1); // 64 bytes
+}
+
+async function generateAESKeyFrom(pkey, skey){
+  // expect pkey length 64, add 0x04
+  if(pkey.length === 64){
+    pkey = new Uint8Array([0x04,...pkey]);
+  }
+  // noble 返回压缩形式的共享点(33字节)时，将其再过一层 sha256，与 Node 端 hashfn 行为等价
+  const sharedCompressed = getSharedSecret(skey, pkey, true); // 33 bytes
+  const ecdhHash = await sha256Bytes(sharedCompressed); // 32 bytes
+  const key_derive_key = aesCmac(cmac_key, ecdhHash);
+  let derivation_buffer = new Uint8Array(aad.length + 4);
+  derivation_buffer[0] = 0x01;
+  derivation_buffer.set(aad,1);
+  derivation_buffer[aad.length+1]=0;
+  derivation_buffer[aad.length+2]=0x80;
+  derivation_buffer[aad.length+3]=0x00;
+  const derived_key = aesCmac(key_derive_key, derivation_buffer);
+  return derived_key; // 16 bytes for AES-128-GCM
+}
+
+async function decryptMessage(privKeyHex, msg){
+  const skey = hexToBytes(privKeyHex);
+  const total = msg.length;
+  const encrypted = msg.slice(0, total - 64 - 16 - 12);
+  const liv = msg.slice(encrypted.length, total - 64 - 16);
+  const pkey = msg.slice(encrypted.length + 12, total - 16); // 64 bytes
+  const tag = msg.slice(total - 16);
+  const enc_key = await generateAESKeyFrom(pkey, skey);
+  // WebCrypto decrypt
+  const key = await crypto.subtle.importKey('raw', enc_key, {name:'AES-GCM'}, false, ['decrypt']);
+  const tad = new Uint8Array(64);
+  tad.set(aad);
+  tad[24] = 0x2; // prefix
+  // Need concat encrypted+tag? WebCrypto expects separate tag appended to ciphertext (last 16 bytes). Already separated; we must reconstruct
+  const cipherAll = new Uint8Array(encrypted.length + tag.length);
+  cipherAll.set(encrypted,0); cipherAll.set(tag, encrypted.length);
+  const plain = await crypto.subtle.decrypt({name:'AES-GCM', iv: liv, additionalData: tad, tagLength:128}, key, cipherAll);
+  // 与 Node 端逻辑保持一致：Node 在解密后返回的是原始明文字节（不是 ASCII hex），这里直接返回原始 bytes
+  return new Uint8Array(plain);
+}
+
+export const BrowserCrypto = { decryptMessage, generatePublicKeyFromPrivateKey };
+export default BrowserCrypto;

--- a/src/browser/ypccrypto.browser.js
+++ b/src/browser/ypccrypto.browser.js
@@ -1,12 +1,14 @@
 // Browser implementation of ypccrypto decrypt logic using @noble/secp256k1 and WebCrypto
 // Derivation mimics aes-cmac based scheme from node version using pure JS AES-CMAC.
 import {getPublicKey, getSharedSecret} from '@noble/secp256k1';
-import AES from 'aes-js';
+// 直接从 aes-js 顶层入口导入 ECB 模式（4.x import 指向 ESM lib.esm/index.js）
+// 旧版用的是 AES.ModeOfOperation.ecb，这里在 4.x 中等价于单独导出的 ECB 类
+import { ECB } from 'aes-js';
 
 // aes-cmac implementation (simplified) based on AES-128
 function aesCmac(key, message){
   // Generate subkeys per RFC 4493
-  const aes = new AES.ModeOfOperation.ecb(key);
+  const aes = new ECB(key);
   const blockSize = 16;
   function leftShift(buf){
     const out = new Uint8Array(buf.length);

--- a/src/header_util.js
+++ b/src/header_util.js
@@ -1,7 +1,4 @@
-import * as ByteBufferNS from "bytebuffer";
-
-const ByteBuffer = /** @type {any} */ (ByteBufferNS);
-const LITTLE_ENDIAN = ByteBuffer.LITTLE_ENDIAN;
+import ByteBuffer, { LITTLE_ENDIAN } from "bytebuffer";
 // 32 bytes
 export const header_t = function(magic_number, version_number, block_number, item_number) {
   if (new.target == undefined) {

--- a/src/header_util.js
+++ b/src/header_util.js
@@ -1,6 +1,7 @@
-import ByteBuffer, {
-  LITTLE_ENDIAN
-} from "bytebuffer";
+import * as ByteBufferNS from "bytebuffer";
+
+const ByteBuffer = /** @type {any} */ (ByteBufferNS);
+const LITTLE_ENDIAN = ByteBuffer.LITTLE_ENDIAN;
 // 32 bytes
 export const header_t = function(magic_number, version_number, block_number, item_number) {
   if (new.target == undefined) {

--- a/src/index.browser.js
+++ b/src/index.browser.js
@@ -1,0 +1,11 @@
+/* eslint-disable */
+import { BrowserCrypto } from "./browser/ypccrypto.browser.js";
+
+export const YPCCrypto = BrowserCrypto;
+
+export { BrowserCrypto };
+
+export { UnsealerBrowser, unsealStream } from "./browser/UnsealerBrowser.js";
+
+export { downloadUnsealed } from "./browser/downloadUnsealed.js";
+

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,24 @@
 /* eslint-disable */
 import Provider from "./DataProvider";
-import ypccrypto from "./ypccrypto";
 import YPCNt_Object from "./ypcntobject";
+// Node.js 环境：使用静态导入（默认）
+import nodeYPCCrypto from "./ypccrypto.js";
+// 浏览器环境：使用静态导入（Rollup 会在 ESM 构建时内联打包）
+// 注意：CommonJS 构建也会包含此导入，但由于运行在 Node.js 环境，isBrowser 为 false，不会被使用
+import browserYPCCrypto from "./browser/ypccrypto.browser.js";
+
+// 根据环境自动选择 ypccrypto 实现
+// 检测浏览器环境：使用多重条件确保准确性
+// 优先检查明确的浏览器对象，而不是依赖 process 的不存在（因为构建工具可能会 polyfill process）
+const isBrowser = typeof window !== 'undefined' || 
+                  (typeof globalThis !== 'undefined' && globalThis.WorkerGlobalScope) ||
+                  (typeof self !== 'undefined' && self.WorkerGlobalScope);
+
+// 直接选择对应的实现（同步，无需异步加载）
+// 对于 ESM 构建：Rollup 会内联打包浏览器版本，两个导入都存在
+// 对于 CommonJS 构建：浏览器版本也会被打包，但由于运行在 Node.js 环境，isBrowser 为 false，使用 Node 版本
+const YPCCryptoClass = isBrowser ? browserYPCCrypto : nodeYPCCrypto;
+
 export { Sealer, ToString } from "./Sealer.js";
 
 export { Unsealer } from "./Unsealer.js";
@@ -22,4 +39,4 @@ export {
 export const { DataProvider, checkSealedData, unsealData } = Provider;
 
 export const YPCNtObject = YPCNt_Object();
-export const YPCCrypto = ypccrypto();
+export const YPCCrypto = YPCCryptoClass();

--- a/src/index.node.js
+++ b/src/index.node.js
@@ -1,0 +1,27 @@
+/* eslint-disable */
+import Provider from "./DataProvider";
+import YPCNt_Object from "./ypcntobject";
+import nodeYPCCrypto from "./ypccrypto.js";
+
+export { Sealer, ToString } from "./Sealer.js";
+
+export { Unsealer } from "./Unsealer.js";
+
+export { SealedFileStream } from "./SealedFileStream.js";
+export {PipelineContext, PipelineContextInFile} from "./PipelineConext.js";
+export {RecoverableReadStream, RecoverableWriteStream} from "./Recoverable.js";
+
+export {
+  isSealedFile,
+  sealedFileVersion,
+  dataHashOfSealedFile,
+  signedDataHash,
+  forwardSkey,
+  calculateSealedHash
+} from "./SealedFileUtil.js";
+
+export const { DataProvider, checkSealedData, unsealData } = Provider;
+
+export const YPCNtObject = YPCNt_Object();
+export const YPCCrypto = nodeYPCCrypto();
+

--- a/src/ypccrypto.js
+++ b/src/ypccrypto.js
@@ -1,6 +1,6 @@
 import crypto from "crypto";
 import keccak256 from "keccak256";
-import { aesCmac } from "./node-aes-cmac/index";
+import { aesCmac } from "./node-aes-cmac/index.js";
 import secp256k1 from "secp256k1";
 import { sha256 } from "js-sha256";
 

--- a/test/BrowserCrypto.spec.js
+++ b/test/BrowserCrypto.spec.js
@@ -1,0 +1,368 @@
+// BrowserCrypto comprehensive test - compare with Node YPCCrypto for consistency
+import { webcrypto as nodeWebcrypto } from 'crypto';
+globalThis.crypto = nodeWebcrypto;
+
+import { BrowserCrypto } from '../src/browser/ypccrypto.browser.js';
+import YPCCryptoFun from '../src/ypccrypto.js';
+
+describe('BrowserCrypto compatibility with Node YPCCrypto', () => {
+  let nodeCrypto;
+  let browserCrypto;
+
+  beforeEach(() => {
+    nodeCrypto = YPCCryptoFun();
+    browserCrypto = BrowserCrypto;
+  });
+
+  describe('Key Generation', () => {
+    test('generatePrivateKey should generate valid 32-byte private key', () => {
+      const nodeKey = nodeCrypto.generatePrivateKey();
+      const browserKey = browserCrypto.generatePrivateKey();
+
+      expect(Buffer.isBuffer(nodeKey)).toBe(true);
+      expect(nodeKey.length).toBe(32);
+      
+      expect(browserKey instanceof Uint8Array).toBe(true);
+      expect(browserKey.length).toBe(32);
+    });
+
+    test('generatePublicKeyFromPrivateKey should produce consistent results', () => {
+      // Use fixed test private key for deterministic results
+      const testPrivateKey = Buffer.from('60d61a1d92b26608016dba8cb8e8e96fd44d5dee0a0415a024657e47febcced8', 'hex');
+      
+      const nodePublicKey = nodeCrypto.generatePublicKeyFromPrivateKey(testPrivateKey);
+      const browserPublicKey = browserCrypto.generatePublicKeyFromPrivateKey(testPrivateKey);
+
+      expect(Buffer.isBuffer(nodePublicKey)).toBe(true);
+      expect(nodePublicKey.length).toBe(64);
+      
+      expect(browserPublicKey instanceof Uint8Array).toBe(true);
+      expect(browserPublicKey.length).toBe(64);
+      
+      // Compare as hex strings
+      expect(nodePublicKey.toString('hex')).toBe(Buffer.from(browserPublicKey).toString('hex'));
+    });
+
+    test('generatePublicKeyFromPrivateKey with random keys should match', () => {
+      const nodeKey = nodeCrypto.generatePrivateKey();
+      const browserKey = browserCrypto.generatePrivateKey();
+      
+      // Convert browser key to Buffer for comparison
+      const browserKeyBuf = Buffer.from(browserKey);
+      
+      // Test with same private key
+      const nodePKey = nodeCrypto.generatePublicKeyFromPrivateKey(nodeKey);
+      const browserPKey = browserCrypto.generatePublicKeyFromPrivateKey(nodeKey);
+      
+      expect(nodePKey.toString('hex')).toBe(Buffer.from(browserPKey).toString('hex'));
+      
+      // Test with browser-generated key
+      const browserPKey2 = browserCrypto.generatePublicKeyFromPrivateKey(browserKeyBuf);
+      const nodePKey2 = nodeCrypto.generatePublicKeyFromPrivateKey(browserKeyBuf);
+      
+      expect(nodePKey2.toString('hex')).toBe(Buffer.from(browserPKey2).toString('hex'));
+    });
+  });
+
+  describe('AES Key Generation', () => {
+    test('generateAESKeyFrom should produce same AES key for same inputs', async () => {
+      const testPrivateKey = Buffer.from('60d61a1d92b26608016dba8cb8e8e96fd44d5dee0a0415a024657e47febcced8', 'hex');
+      const testPublicKey = Buffer.from('731234931a081e9beae856318a9bf32ac3698ea8215bf74f517f8377cc6ba8740e28ed87c97d0ee8775bc83505867b0bc34a66adc91f0ea9b44c80533f1a3dca', 'hex');
+      
+      const nodeAESKey = nodeCrypto.generateAESKeyFrom(testPublicKey, testPrivateKey);
+      const browserAESKey = await browserCrypto.generateAESKeyFrom(testPublicKey, testPrivateKey);
+
+      expect(Buffer.isBuffer(nodeAESKey)).toBe(true);
+      expect(nodeAESKey.length).toBe(16); // AES-128 key length
+      
+      expect(browserAESKey instanceof Uint8Array).toBe(true);
+      expect(browserAESKey.length).toBe(16);
+      
+      // Compare keys
+      expect(nodeAESKey.toString('hex')).toBe(Buffer.from(browserAESKey).toString('hex'));
+    });
+
+    test('generateAESKeyFrom should work with random key pairs', async () => {
+      const nodeKey = nodeCrypto.generatePrivateKey();
+      const nodePKey = nodeCrypto.generatePublicKeyFromPrivateKey(nodeKey);
+      
+      const nodeAESKey = nodeCrypto.generateAESKeyFrom(nodePKey, nodeKey);
+      const browserAESKey = await browserCrypto.generateAESKeyFrom(nodePKey, nodeKey);
+
+      expect(nodeAESKey.toString('hex')).toBe(Buffer.from(browserAESKey).toString('hex'));
+    });
+  });
+
+  describe('Encryption and Decryption', () => {
+    test('_encryptMessage should produce decryptable ciphertext', async () => {
+      const testPrivateKey = Buffer.from('60d61a1d92b26608016dba8cb8e8e96fd44d5dee0a0415a024657e47febcced8', 'hex');
+      const testPublicKey = Buffer.from('731234931a081e9beae856318a9bf32ac3698ea8215bf74f517f8377cc6ba8740e28ed87c97d0ee8775bc83505867b0bc34a66adc91f0ea9b44c80533f1a3dca', 'hex');
+      const testMessage = Buffer.from('hello world', 'utf8');
+      const prefix = 0x2;
+
+      // Generate one-time secret for encryption
+      const nodeOTS = nodeCrypto.generatePrivateKey();
+      const browserOTS = browserCrypto.generatePrivateKey();
+      
+      // Test with same OTS
+      const nodeEncrypted = nodeCrypto._encryptMessage(testPublicKey, nodeOTS, testMessage, prefix);
+      const browserEncrypted = await browserCrypto._encryptMessage(testPublicKey, nodeOTS, testMessage, prefix);
+
+      expect(Buffer.isBuffer(nodeEncrypted)).toBe(true);
+      expect(browserEncrypted instanceof Uint8Array).toBe(true);
+      
+      // Note: Due to random IV, encrypted outputs will differ even with same inputs
+      // But both should be decryptable with the same private key
+      const nodeDecrypted = nodeCrypto.decryptMessage(testPrivateKey, nodeEncrypted);
+      const browserDecrypted = await browserCrypto.decryptMessage(testPrivateKey, nodeEncrypted);
+      
+      expect(nodeDecrypted.toString('utf8')).toBe(testMessage.toString('utf8'));
+      expect(Buffer.from(browserDecrypted).toString('utf8')).toBe(testMessage.toString('utf8'));
+      
+      // Also test decrypting browser-encrypted message with node
+      const browserDecryptedByNode = nodeCrypto.decryptMessage(testPrivateKey, browserEncrypted);
+      expect(browserDecryptedByNode.toString('utf8')).toBe(testMessage.toString('utf8'));
+    });
+
+    test('decryptMessage should decrypt messages encrypted by Node version', async () => {
+      const testPrivateKey = Buffer.from('60d61a1d92b26608016dba8cb8e8e96fd44d5dee0a0415a024657e47febcced8', 'hex');
+      const testPublicKey = Buffer.from('731234931a081e9beae856318a9bf32ac3698ea8215bf74f517f8377cc6ba8740e28ed87c97d0ee8775bc83505867b0bc34a66adc91f0ea9b44c80533f1a3dca', 'hex');
+      const testMessage = Buffer.from('test message for decryption', 'utf8');
+
+      // Encrypt with Node version
+      const nodeOTS = nodeCrypto.generatePrivateKey();
+      const nodeEncrypted = nodeCrypto._encryptMessage(testPublicKey, nodeOTS, testMessage, 0x2);
+
+      // Decrypt with Browser version
+      const browserDecrypted = await browserCrypto.decryptMessage(testPrivateKey, nodeEncrypted);
+      
+      expect(Buffer.from(browserDecrypted).toString('utf8')).toBe(testMessage.toString('utf8'));
+    });
+
+    test('decryptMessage should decrypt messages encrypted by Browser version', async () => {
+      const testPrivateKey = Buffer.from('60d61a1d92b26608016dba8cb8e8e96fd44d5dee0a0415a024657e47febcced8', 'hex');
+      const testPublicKey = Buffer.from('731234931a081e9beae856318a9bf32ac3698ea8215bf74f517f8377cc6ba8740e28ed87c97d0ee8775bc83505867b0bc34a66adc91f0ea9b44c80533f1a3dca', 'hex');
+      const testMessage = Buffer.from('test message for browser encryption', 'utf8');
+
+      // Encrypt with Browser version
+      const browserOTS = browserCrypto.generatePrivateKey();
+      const browserEncrypted = await browserCrypto._encryptMessage(testPublicKey, browserOTS, testMessage, 0x2);
+
+      // Decrypt with Node version
+      const nodeDecrypted = nodeCrypto.decryptMessage(testPrivateKey, browserEncrypted);
+      
+      expect(nodeDecrypted.toString('utf8')).toBe(testMessage.toString('utf8'));
+    });
+
+    test('_decryptMessageWithPrefix should work with different prefixes', async () => {
+      const testPrivateKey = Buffer.from('60d61a1d92b26608016dba8cb8e8e96fd44d5dee0a0415a024657e47febcced8', 'hex');
+      const testPublicKey = Buffer.from('731234931a081e9beae856318a9bf32ac3698ea8215bf74f517f8377cc6ba8740e28ed87c97d0ee8775bc83505867b0bc34a66adc91f0ea9b44c80533f1a3dca', 'hex');
+      const testMessage = Buffer.from('test with prefix 0x1', 'utf8');
+
+      // Test prefix 0x1 (forward message)
+      const nodeOTS = nodeCrypto.generatePrivateKey();
+      const nodeEncrypted = nodeCrypto._encryptMessage(testPublicKey, nodeOTS, testMessage, 0x1);
+      
+      const browserDecrypted = await browserCrypto._decryptMessageWithPrefix(testPrivateKey, nodeEncrypted, 0x1);
+      expect(Buffer.from(browserDecrypted).toString('utf8')).toBe(testMessage.toString('utf8'));
+      
+      // Test prefix 0x2 (normal message)
+      const nodeEncrypted2 = nodeCrypto._encryptMessage(testPublicKey, nodeOTS, testMessage, 0x2);
+      const browserDecrypted2 = await browserCrypto._decryptMessageWithPrefix(testPrivateKey, nodeEncrypted2, 0x2);
+      expect(Buffer.from(browserDecrypted2).toString('utf8')).toBe(testMessage.toString('utf8'));
+    });
+
+    test('decryptForwardMessage should decrypt forward messages', async () => {
+      const testPrivateKey = Buffer.from('60d61a1d92b26608016dba8cb8e8e96fd44d5dee0a0415a024657e47febcced8', 'hex');
+      const testPublicKey = Buffer.from('731234931a081e9beae856318a9bf32ac3698ea8215bf74f517f8377cc6ba8740e28ed87c97d0ee8775bc83505867b0bc34a66adc91f0ea9b44c80533f1a3dca', 'hex');
+      const testMessage = Buffer.from('forward message', 'utf8');
+
+      // Encrypt forward message with Node
+      const nodeOTS = nodeCrypto.generatePrivateKey();
+      const nodeEncrypted = nodeCrypto._encryptMessage(testPublicKey, nodeOTS, testMessage, 0x1);
+
+      // Decrypt with Browser decryptForwardMessage
+      const browserDecrypted = await browserCrypto.decryptForwardMessage(testPrivateKey, nodeEncrypted);
+      expect(Buffer.from(browserDecrypted).toString('utf8')).toBe(testMessage.toString('utf8'));
+    });
+  });
+
+  describe('Forward Secret Key Generation', () => {
+    test('generateForwardSecretKey should produce decryptable result', async () => {
+      const remotePKey = Buffer.from('731234931a081e9beae856318a9bf32ac3698ea8215bf74f517f8377cc6ba8740e28ed87c97d0ee8775bc83505867b0bc34a66adc91f0ea9b44c80533f1a3dca', 'hex');
+      const localSKey = Buffer.from('60d61a1d92b26608016dba8cb8e8e96fd44d5dee0a0415a024657e47febcced8', 'hex');
+
+      const nodeForwardKey = nodeCrypto.generateForwardSecretKey(remotePKey, localSKey);
+      const browserForwardKey = await browserCrypto.generateForwardSecretKey(remotePKey, localSKey);
+
+      expect(Buffer.isBuffer(nodeForwardKey)).toBe(true);
+      expect(browserForwardKey instanceof Uint8Array).toBe(true);
+      
+      // Both should be decryptable with remote private key
+      // (Assuming we have the remote private key for testing)
+      // Since we're using different OTS, outputs will differ, but both should be valid
+      
+      // Verify structure: should be encrypted message format (ciphertext + iv + pkey + tag)
+      expect(nodeForwardKey.length).toBeGreaterThan(64 + 16 + 12); // at least pkey + tag + iv
+      expect(browserForwardKey.length).toBeGreaterThan(64 + 16 + 12);
+    });
+  });
+
+  describe('Encrypted Input Generation', () => {
+    test('generateEncryptedInput should produce valid encrypted input', async () => {
+      const localPKey = Buffer.from('731234931a081e9beae856318a9bf32ac3698ea8215bf74f517f8377cc6ba8740e28ed87c97d0ee8775bc83505867b0bc34a66adc91f0ea9b44c80533f1a3dca', 'hex');
+      const testInput = { buffer: Buffer.from('test input data', 'utf8') };
+
+      const nodeEncrypted = nodeCrypto.generateEncryptedInput(localPKey, testInput);
+      const browserEncrypted = await browserCrypto.generateEncryptedInput(localPKey, testInput);
+
+      expect(Buffer.isBuffer(nodeEncrypted)).toBe(true);
+      expect(browserEncrypted instanceof Uint8Array).toBe(true);
+      
+      // Both should be valid encrypted messages
+      expect(nodeEncrypted.length).toBeGreaterThan(64 + 16 + 12);
+      expect(browserEncrypted.length).toBeGreaterThan(64 + 16 + 12);
+    });
+  });
+
+  describe('File Name and Content Generation', () => {
+    test('generateFileNameFromPKey should produce consistent results', () => {
+      const testPKey = Buffer.from('731234931a081e9beae856318a9bf32ac3698ea8215bf74f517f8377cc6ba8740e28ed87c97d0ee8775bc83505867b0bc34a66adc91f0ea9b44c80533f1a3dca', 'hex');
+      
+      const nodeFileName = nodeCrypto.generateFileNameFromPKey(testPKey);
+      const browserFileName = browserCrypto.generateFileNameFromPKey(testPKey);
+
+      expect(typeof nodeFileName).toBe('string');
+      expect(typeof browserFileName).toBe('string');
+      expect(nodeFileName).toBe(browserFileName);
+      expect(nodeFileName).toMatch(/^[0-9a-f]{8}\.json$/);
+    });
+
+    test('generateFileContentFromSKey should produce consistent results', () => {
+      const testSKey = Buffer.from('60d61a1d92b26608016dba8cb8e8e96fd44d5dee0a0415a024657e47febcced8', 'hex');
+      
+      const nodeFileContent = nodeCrypto.generateFileContentFromSKey(testSKey);
+      const browserFileContent = browserCrypto.generateFileContentFromSKey(testSKey);
+
+      expect(typeof nodeFileContent).toBe('string');
+      expect(typeof browserFileContent).toBe('string');
+      
+      // Parse JSON to compare
+      const nodeObj = JSON.parse(nodeFileContent);
+      const browserObj = JSON.parse(browserFileContent);
+      
+      expect(nodeObj.private_key).toBe(browserObj.private_key);
+      expect(nodeObj.public_key).toBe(browserObj.public_key);
+      expect(nodeObj.private_key).toBe(testSKey.toString('hex'));
+    });
+  });
+
+  describe('Round-trip Encryption/Decryption', () => {
+    test('Browser encrypt -> Browser decrypt should work', async () => {
+      const testPrivateKey = browserCrypto.generatePrivateKey();
+      const testPublicKey = browserCrypto.generatePublicKeyFromPrivateKey(testPrivateKey);
+      const testMessage = new TextEncoder().encode('round trip test message');
+
+      const browserOTS = browserCrypto.generatePrivateKey();
+      const encrypted = await browserCrypto._encryptMessage(testPublicKey, browserOTS, testMessage, 0x2);
+      const decrypted = await browserCrypto.decryptMessage(testPrivateKey, encrypted);
+
+      expect(new TextDecoder().decode(decrypted)).toBe(new TextDecoder().decode(testMessage));
+    });
+
+    test('Browser encrypt -> Node decrypt should work', async () => {
+      const testPrivateKey = browserCrypto.generatePrivateKey();
+      const testPublicKey = browserCrypto.generatePublicKeyFromPrivateKey(testPrivateKey);
+      const testMessage = Buffer.from('browser to node test', 'utf8');
+
+      const browserOTS = browserCrypto.generatePrivateKey();
+      const encrypted = await browserCrypto._encryptMessage(testPublicKey, browserOTS, testMessage, 0x2);
+      const decrypted = nodeCrypto.decryptMessage(Buffer.from(testPrivateKey), encrypted);
+
+      expect(decrypted.toString('utf8')).toBe(testMessage.toString('utf8'));
+    });
+
+    test('Node encrypt -> Browser decrypt should work', async () => {
+      const testPrivateKey = nodeCrypto.generatePrivateKey();
+      const testPublicKey = nodeCrypto.generatePublicKeyFromPrivateKey(testPrivateKey);
+      const testMessage = Buffer.from('node to browser test', 'utf8');
+
+      const nodeOTS = nodeCrypto.generatePrivateKey();
+      const encrypted = nodeCrypto._encryptMessage(testPublicKey, nodeOTS, testMessage, 0x2);
+      const decrypted = await browserCrypto.decryptMessage(testPrivateKey, encrypted);
+
+      expect(Buffer.from(decrypted).toString('utf8')).toBe(testMessage.toString('utf8'));
+    });
+  });
+
+  describe('Signature Consistency (no verification)', () => {
+    test('signMessage should produce consistent signatures for same input', () => {
+      const testPrivateKey = Buffer.from('60d61a1d92b26608016dba8cb8e8e96fd44d5dee0a0415a024657e47febcced8', 'hex');
+      const testMessage = Buffer.from('test message for signing', 'utf8');
+
+      const nodeSignature = nodeCrypto.signMessage(testPrivateKey, testMessage);
+      const browserSignature = browserCrypto.signMessage(testPrivateKey, testMessage);
+
+      expect(Buffer.isBuffer(nodeSignature)).toBe(true);
+      expect(nodeSignature.length).toBe(65); // 64 bytes (r, s) + 1 byte (recovery + 27)
+      
+      expect(browserSignature instanceof Uint8Array).toBe(true);
+      expect(browserSignature.length).toBe(65);
+
+      // Compare signatures - should be identical for same input (deterministic signing)
+      expect(nodeSignature.toString('hex')).toBe(Buffer.from(browserSignature).toString('hex'));
+    });
+
+    test('signMessage should produce consistent signatures with different message types', () => {
+      const testPrivateKey = Buffer.from('60d61a1d92b26608016dba8cb8e8e96fd44d5dee0a0415a024657e47febcced8', 'hex');
+      const testMessages = [
+        Buffer.from('simple text', 'utf8'),
+        Buffer.from([0x00, 0x01, 0x02, 0x03, 0xff, 0xfe, 0xfd]),
+        Buffer.alloc(32, 0x42), // 32 bytes of 0x42
+      ];
+
+      for (const testMessage of testMessages) {
+        const nodeSignature = nodeCrypto.signMessage(testPrivateKey, testMessage);
+        const browserSignature = browserCrypto.signMessage(testPrivateKey, testMessage);
+
+        expect(nodeSignature.toString('hex')).toBe(Buffer.from(browserSignature).toString('hex'));
+      }
+    });
+
+    test('generateSignature should produce consistent signatures', () => {
+      const testPrivateKey = Buffer.from('60d61a1d92b26608016dba8cb8e8e96fd44d5dee0a0415a024657e47febcced8', 'hex');
+      const testEPKey = Buffer.from('731234931a081e9beae856318a9bf32ac3698ea8215bf74f517f8377cc6ba874', 'hex');
+      const testEHash = Buffer.alloc(32, 0xaa); // 32 bytes of 0xaa
+
+      const nodeSignature = nodeCrypto.generateSignature(testPrivateKey, testEPKey, testEHash);
+      const browserSignature = browserCrypto.generateSignature(testPrivateKey, testEPKey, testEHash);
+
+      expect(Buffer.isBuffer(nodeSignature)).toBe(true);
+      expect(nodeSignature.length).toBe(65);
+      
+      expect(browserSignature instanceof Uint8Array).toBe(true);
+      expect(browserSignature.length).toBe(65);
+
+      // Compare signatures - should be identical
+      expect(nodeSignature.toString('hex')).toBe(Buffer.from(browserSignature).toString('hex'));
+    });
+
+    test('signMessage with random keys should produce consistent signatures', () => {
+      const nodeKey = nodeCrypto.generatePrivateKey();
+      const browserKey = browserCrypto.generatePrivateKey();
+      const testMessage = Buffer.from('random key test', 'utf8');
+
+      // Test with same private key (node-generated)
+      const nodeSig1 = nodeCrypto.signMessage(nodeKey, testMessage);
+      const browserSig1 = browserCrypto.signMessage(nodeKey, testMessage);
+      expect(nodeSig1.toString('hex')).toBe(Buffer.from(browserSig1).toString('hex'));
+
+      // Test with browser-generated key converted to Buffer
+      const browserKeyBuf = Buffer.from(browserKey);
+      const nodeSig2 = nodeCrypto.signMessage(browserKeyBuf, testMessage);
+      const browserSig2 = browserCrypto.signMessage(browserKeyBuf, testMessage);
+      expect(nodeSig2.toString('hex')).toBe(Buffer.from(browserSig2).toString('hex'));
+    });
+  });
+});
+

--- a/test/BrowserUnsealer.spec.js
+++ b/test/BrowserUnsealer.spec.js
@@ -1,0 +1,75 @@
+import { webcrypto as nodeWebcrypto } from 'crypto';
+globalThis.crypto = nodeWebcrypto;
+
+import streams from 'memory-streams';
+import Provider from '../src/DataProvider.js';
+import { BlockInfoSize, HeaderSize } from '../src/limits.js';
+import YPCCryptoFun from '../src/ypccrypto.js';
+import { UnsealerBrowser } from '../src/browser/UnsealerBrowser.js';
+
+const { DataProvider, headerAndBlockBufferFromBuffer } = Provider;
+
+describe('Browser Unsealer compatibility', () => {
+  it('should decrypt to original content (single chunk input)', async () => {
+    const YPCCrypto = YPCCryptoFun();
+    const sk = YPCCrypto.generatePrivateKey();
+    const pk = YPCCrypto.generatePublicKeyFromPrivateKey(sk);
+    const keyPair = { private_key: sk.toString('hex'), public_key: pk.toString('hex') };
+
+    const dp = new DataProvider(keyPair);
+    const ws = new streams.WritableStream();
+    dp.sealData('hello world', ws, false);
+    dp.sealData(null, ws, true);
+    const diskBuf = ws.toBuffer();
+
+    const hb = headerAndBlockBufferFromBuffer(diskBuf);
+    expect(hb).toBeTruthy();
+    const header = hb.header;
+    const blockCount = (hb.block.length / BlockInfoSize) | 0;
+    const contentSize = diskBuf.length - HeaderSize - BlockInfoSize * blockCount;
+    const content = diskBuf.slice(0, contentSize);
+    const streamBuf = Buffer.concat([header, content]);
+
+    const un = new UnsealerBrowser({ privateKeyHex: keyPair.private_key });
+    const chunks = [];
+    // feed header and content in two parts to simulate streaming
+    chunks.push(...(await un.pushChunk(streamBuf.slice(0, HeaderSize))));
+    chunks.push(...(await un.pushChunk(streamBuf.slice(HeaderSize))));
+    const merged = Buffer.concat(chunks.map(b=>Buffer.from(b)));
+    expect(merged.toString('utf8')).toBe('hello world');
+  }, 20000);
+
+  it('should decrypt multiple inputs batched', async () => {
+    const YPCCrypto = YPCCryptoFun();
+    const sk = YPCCrypto.generatePrivateKey();
+    const pk = YPCCrypto.generatePublicKeyFromPrivateKey(sk);
+    const keyPair = { private_key: sk.toString('hex'), public_key: pk.toString('hex') };
+
+    const dp = new DataProvider(keyPair);
+    const ws = new streams.WritableStream();
+    const inputs = ['alpha','beta','gamma'];
+    for(const s of inputs){ dp.sealData(s, ws, false); }
+    dp.sealData(null, ws, true);
+    const diskBuf = ws.toBuffer();
+
+    const hb = headerAndBlockBufferFromBuffer(diskBuf);
+    const header = hb.header; const blockCount = (hb.block.length / BlockInfoSize)|0;
+    const contentSize = diskBuf.length - HeaderSize - BlockInfoSize * blockCount;
+    const content = diskBuf.slice(0, contentSize);
+    const streamBuf = Buffer.concat([header, content]);
+
+    const un = new UnsealerBrowser({ privateKeyHex: keyPair.private_key });
+    const outputs = [];
+    // feed random chunk sizes
+    let offset = 0; const sizes = [13, 7, 1024, 5, 256];
+    let idx=0; while(offset < streamBuf.length){
+      const n = Math.min(streamBuf.length - offset, sizes[idx % sizes.length]);
+      const part = streamBuf.slice(offset, offset+n);
+      const outs = await un.pushChunk(part);
+      outputs.push(...outs);
+      offset+=n; idx++;
+    }
+    const merged = Buffer.concat(outputs.map(b=>Buffer.from(b)));
+    expect(merged.toString('utf8')).toBe(inputs.join(''));
+  }, 20000);
+});

--- a/test/BrowserUnsealerFull.spec.js
+++ b/test/BrowserUnsealerFull.spec.js
@@ -1,0 +1,167 @@
+// Browser Unsealer full test - similar to Unsealer.spec.js but using browser crypto
+import { webcrypto as nodeWebcrypto } from 'crypto';
+globalThis.crypto = nodeWebcrypto;
+
+import streams from 'memory-streams';
+import Provider from '../src/DataProvider.js';
+import { BlockInfoSize, HeaderSize } from '../src/limits.js';
+import { BrowserCrypto } from '../src/browser/ypccrypto.browser.js';
+import { UnsealerBrowser } from '../src/browser/UnsealerBrowser.js';
+import { calculateMD5, generateFileWithSize } from './helper';
+import fs from 'fs';
+import path from 'path';
+
+const { DataProvider, headerAndBlockBufferFromBuffer } = Provider;
+
+// Helper function to convert Uint8Array to Buffer for MD5 calculation
+function uint8ArrayToBuffer(uint8Array) {
+  return Buffer.from(uint8Array);
+}
+
+// Helper function to convert Buffer to Uint8Array
+function bufferToUint8Array(buffer) {
+  return new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+}
+
+async function sealAndUnsealFileBrowser(src) {
+  // Generate key pair using browser crypto
+  const sk = BrowserCrypto.generatePrivateKey();
+  const pk = BrowserCrypto.generatePublicKeyFromPrivateKey(sk);
+  const keyPair = { 
+    private_key: typeof sk === 'string' ? sk : Buffer.from(sk).toString('hex'), 
+    public_key: typeof pk === 'string' ? pk : Buffer.from(pk).toString('hex') 
+  };
+
+  // Encrypt using Node DataProvider (since browser doesn't have Sealer stream)
+  const dp = new DataProvider(keyPair);
+  const ws = new streams.WritableStream();
+  
+  // Read source file and encrypt it in chunks
+  const fileContent = fs.readFileSync(src);
+  const chunkSize = 64 * 1024; // 64KB chunks
+  for (let offset = 0; offset < fileContent.length; offset += chunkSize) {
+    const chunk = fileContent.slice(offset, Math.min(offset + chunkSize, fileContent.length));
+    dp.sealData(chunk, ws, false);
+  }
+  dp.sealData(null, ws, true);
+  
+  const diskBuf = ws.toBuffer();
+  
+  // Extract header and content
+  const hb = headerAndBlockBufferFromBuffer(diskBuf);
+  expect(hb).toBeTruthy();
+  const header = hb.header;
+  const blockCount = (hb.block.length / BlockInfoSize) | 0;
+  const contentSize = diskBuf.length - HeaderSize - BlockInfoSize * blockCount;
+  const content = diskBuf.slice(0, contentSize);
+  const streamBuf = Buffer.concat([header, content]);
+  
+  // Decrypt using browser UnsealerBrowser
+  const un = new UnsealerBrowser({ privateKeyHex: keyPair.private_key });
+  const chunks = [];
+  
+  // Feed data in chunks to simulate streaming
+  const feedChunkSize = 1024; // 1KB chunks for testing
+  for (let offset = 0; offset < streamBuf.length; offset += feedChunkSize) {
+    const chunk = streamBuf.slice(offset, Math.min(offset + feedChunkSize, streamBuf.length));
+    const decryptedChunks = await un.pushChunk(bufferToUint8Array(chunk));
+    chunks.push(...decryptedChunks);
+  }
+  
+  // Merge all decrypted chunks
+  const mergedBuffers = chunks.map(chunk => 
+    Buffer.from(chunk instanceof Uint8Array ? chunk : new Uint8Array(chunk))
+  );
+  const decryptedContent = Buffer.concat(mergedBuffers);
+  
+  // Verify content matches
+  const originalMD5 = await calculateMD5(src);
+  const decryptedFile = path.join(path.dirname(src), path.basename(src) + '.browser.unsealed');
+  fs.writeFileSync(decryptedFile, decryptedContent);
+  const decryptedMD5 = await calculateMD5(decryptedFile);
+  
+  expect(originalMD5.length > 0).toBe(true);
+  expect(originalMD5).toStrictEqual(decryptedMD5);
+  
+  // Cleanup
+  fs.unlinkSync(decryptedFile);
+  
+  return { keyPair, originalMD5, decryptedMD5 };
+}
+
+describe('Browser Unsealer Full Test', () => {
+  test('should encrypt and decrypt small file', async () => {
+    const src = './rollup.config.js';
+    await sealAndUnsealFileBrowser(src);
+  }, 30000);
+
+  test('should encrypt and decrypt medium file', async () => {
+    const src = './README.en.md';
+    await sealAndUnsealFileBrowser(src);
+  }, 30000);
+
+  test('should encrypt and decrypt large file', async () => {
+    const src = 'BrowserUnsealerLarge.file';
+    try {
+      fs.unlinkSync(src);
+    } catch (err) {}
+    
+    // Generate 100MB file
+    generateFileWithSize(src, 1024 * 1024 * 100);
+    await sealAndUnsealFileBrowser(src);
+    
+    try {
+      fs.unlinkSync(src);
+    } catch (err) {}
+  }, 300000);
+
+  test('should handle multiple chunks correctly', async () => {
+    // Test with small data in multiple batches
+    const sk = BrowserCrypto.generatePrivateKey();
+    const pk = BrowserCrypto.generatePublicKeyFromPrivateKey(sk);
+    const keyPair = { 
+      private_key: typeof sk === 'string' ? sk : Buffer.from(sk).toString('hex'), 
+      public_key: typeof pk === 'string' ? pk : Buffer.from(pk).toString('hex') 
+    };
+
+    const dp = new DataProvider(keyPair);
+    const ws = new streams.WritableStream();
+    
+    // Seal multiple small items
+    const inputs = ['alpha', 'beta', 'gamma', 'delta', 'epsilon'];
+    for (const input of inputs) {
+      dp.sealData(Buffer.from(input, 'utf8'), ws, false);
+    }
+    dp.sealData(null, ws, true);
+    
+    const diskBuf = ws.toBuffer();
+    const hb = headerAndBlockBufferFromBuffer(diskBuf);
+    const header = hb.header;
+    const blockCount = (hb.block.length / BlockInfoSize) | 0;
+    const contentSize = diskBuf.length - HeaderSize - BlockInfoSize * blockCount;
+    const content = diskBuf.slice(0, contentSize);
+    const streamBuf = Buffer.concat([header, content]);
+    
+    // Decrypt with UnsealerBrowser
+    const un = new UnsealerBrowser({ privateKeyHex: keyPair.private_key });
+    const outputs = [];
+    
+    // Feed in various chunk sizes to test robustness
+    let offset = 0;
+    const sizes = [13, 7, 1024, 5, 256, 512];
+    let idx = 0;
+    while (offset < streamBuf.length) {
+      const n = Math.min(streamBuf.length - offset, sizes[idx % sizes.length]);
+      const part = streamBuf.slice(offset, offset + n);
+      const outs = await un.pushChunk(bufferToUint8Array(part));
+      outputs.push(...outs);
+      offset += n;
+      idx++;
+    }
+    
+    // Merge outputs
+    const merged = Buffer.concat(outputs.map(b => Buffer.from(b)));
+    expect(merged.toString('utf8')).toBe(inputs.join(''));
+  }, 30000);
+});
+


### PR DESCRIPTION
## 概述
添加浏览器版本的加密/解密实现，确保与 Node.js 版本的功能和结果一致性。

## 主要变更
- 实现浏览器版本的 YPCCrypto，使用 Web Crypto API 和 @noble 库
- 支持加密/解密、签名、密钥生成等核心功能
- 添加 BrowserCrypto 导出，提供与 Node 版本一致的 API
- 实现 UnsealerBrowser，支持浏览器环境下的流式解密
- 添加完整的单元测试，确保与 Node 版本结果一致

## 技术细节
- 使用 `@noble/secp256k1` 进行 ECDSA 签名和 ECDH 密钥交换
- 使用 `@noble/hashes` 进行 SHA3 (keccak256) 和 HMAC-SHA256
- 使用 Web Crypto API 的 AES-GCM 进行加密/解密
- 实现 RFC6979 确定性签名，确保签名一致性

## 测试
- ✅ 所有 BrowserCrypto 功能测试通过
- ✅ 与 Node 版本加密/解密结果一致性验证通过
- ✅ 签名一致性验证通过
- ✅ Unsealer 完整流程测试通过

## 相关文件
- `src/browser/ypccrypto.browser.js` - 浏览器加密实现
- `src/index.browser.js` - 浏览器入口
- `test/BrowserCrypto.spec.js` - 单元测试
- `test/BrowserUnsealerFull.spec.js` - Unsealer 测试