### PR TITLE
fix: resolve CDN redirect before Range requests (5.0.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@yeez-tech/meta-encryptor",
-    "version": "5.0.1",
+    "version": "5.0.2",
     "description": "Data Seal/Unseal for Fidelius",
     "main": "build/commonjs/index.node.cjs",
     "module": "build/es/index.node.js",

--- a/src/browser/HttpSealedFileStream.js
+++ b/src/browser/HttpSealedFileStream.js
@@ -13,7 +13,7 @@
 import { HeaderSize, BlockInfoSize } from '../common/limits.js';
 import { validateHeader } from '../common/unsealer_core.js';
 import { MetaEncryptorError } from '../common/errors.js';
-import { fetchRange } from './fetchRange.js';
+import { fetchRange, resolvedFetchUrl } from './fetchRange.js';
 
 const DEFAULT_CHUNK = 1024 * 1024; // 1 MB per Range request
 
@@ -54,11 +54,13 @@ export class HttpSealedFileStream extends ReadableStream {
           return;
         }
         state.totalSize = totalSize;
+        const fetchUrl = resolvedFetchUrl(headResp, url);
+        state.url = fetchUrl;
 
         const tailStart = totalSize - HeaderSize;
         let tailResp;
         try {
-          const result = await fetchRange(url, { start: tailStart, end: totalSize - 1, fetch: _fetch });
+          const result = await fetchRange(fetchUrl, { start: tailStart, end: totalSize - 1, fetch: _fetch });
           tailResp = result.response;
         } catch (e) {
           controller.error(e);
@@ -88,7 +90,7 @@ export class HttpSealedFileStream extends ReadableStream {
           const chunkEnd = Math.min(pos + CHUNK, state.contentSize);
           let resp;
           try {
-            const result = await fetchRange(url, { start: pos, end: chunkEnd - 1, fetch: _fetch });
+            const result = await fetchRange(fetchUrl, { start: pos, end: chunkEnd - 1, fetch: _fetch });
             resp = result.response;
           } catch (e) {
             controller.error(e);
@@ -106,7 +108,7 @@ export class HttpSealedFileStream extends ReadableStream {
     });
 
     // expose state via public getters
-    this.url = url;
+    this.url = state.url || url;
     this.totalSize = state.totalSize;
     this.blockNumber = state.blockNumber;
     this.contentSize = state.contentSize;

--- a/src/browser/downloadUnsealed.js
+++ b/src/browser/downloadUnsealed.js
@@ -40,14 +40,16 @@ async function inspectSealed(url, log) {
     throw new MetaEncryptorError('ERR_FILE_NOT_SEALED', { detail: { totalSize } });
   }
 
+  const fetchUrl = headResp.url || url;
+  if (fetchUrl !== url) {
+    log(`HEAD redirected to: ${fetchUrl}`);
+  }
+
   const tailStart = totalSize - HeaderSize;
   const rangeHeader = `bytes=${tailStart}-${totalSize - 1}`;
   log(`Range ${rangeHeader} (tail ${HeaderSize} bytes of ${totalSize})`);
 
-  const { response: tailResp, finalUrl } = await fetchRange(url, { start: tailStart, end: totalSize - 1 });
-  if (finalUrl !== url) {
-    log(`Range redirected to: ${finalUrl}`);
-  }
+  const { response: tailResp } = await fetchRange(fetchUrl, { start: tailStart, end: totalSize - 1 });
 
   const tailCl = tailResp.headers.get('Content-Length');
   const contentRange = tailResp.headers.get('Content-Range');

--- a/src/browser/fetchRange.js
+++ b/src/browser/fetchRange.js
@@ -1,9 +1,16 @@
 import { MetaEncryptorError } from '../common/errors.js';
 
-const MAX_REDIRECTS = 10;
+/**
+ * After a HEAD/GET with redirect:'follow', use this URL for Range requests.
+ * Avoids cross-origin opaque-redirect (status 0) when using redirect:'manual',
+ * and avoids Safari dropping Range on auto-redirect follow.
+ */
+export function resolvedFetchUrl(response, requestUrl) {
+  return response.url || requestUrl;
+}
 
 /**
- * @param {string} url
+ * @param {string} url - should be the post-redirect URL from resolvedFetchUrl when possible
  * @param {object} options
  * @param {number} options.start
  * @param {number} options.end
@@ -16,60 +23,38 @@ export async function fetchRange(url, { start, end, fetch: fetchFn, signal } = {
   const rangeHeader = `bytes=${start}-${end}`;
   const expectedLen = end - start + 1;
 
-  let currentUrl = url;
-  let redirectCount = 0;
+  const resp = await _fetch(url, {
+    headers: { Range: rangeHeader },
+    cache: 'no-store',
+    redirect: 'follow',
+    signal,
+  });
 
-  while (redirectCount <= MAX_REDIRECTS) {
-    const resp = await _fetch(currentUrl, {
-      headers: { Range: rangeHeader },
-      redirect: 'manual',
-      signal,
+  if (!resp.ok) {
+    throw new MetaEncryptorError('ERR_CANNOT_READ_TAIL', {
+      detail: { status: resp.status, rangeHeader }
     });
-
-    // Follow 3xx redirects manually, re-applying the Range header each time.
-    // This is needed because Safari drops the Range header on auto-redirect.
-    if (resp.status >= 300 && resp.status < 400 && resp.headers.has('location')) {
-      redirectCount++;
-      if (redirectCount > MAX_REDIRECTS) {
-        throw new MetaEncryptorError('ERR_TOO_MANY_REDIRECTS', {
-          detail: { url, redirectCount: MAX_REDIRECTS }
-        });
-      }
-      const location = resp.headers.get('location');
-      currentUrl = new URL(location, currentUrl).href;
-      continue;
-    }
-
-    if (!resp.ok) {
-      throw new MetaEncryptorError('ERR_CANNOT_READ_TAIL', {
-        detail: { status: resp.status, rangeHeader }
-      });
-    }
-
-    // Detect when a proxy strips the Range header (200 instead of 206).
-    // Some servers also respond 200 with Content-Range, which is valid.
-    if (resp.status === 200) {
-      const contentRange = resp.headers.get('Content-Range');
-      if (!contentRange) {
-        const cl = parseInt(resp.headers.get('Content-Length') || '0', 10);
-        if (cl === 0 || cl > expectedLen * 2) {
-          throw new MetaEncryptorError('ERR_RANGE_NOT_HONORED', {
-            detail: {
-              rangeHeader,
-              expectedStatus: 206,
-              actualStatus: resp.status,
-              contentLength: cl,
-              expectedLength: expectedLen,
-            }
-          });
-        }
-      }
-    }
-
-    return { response: resp, finalUrl: currentUrl };
   }
 
-  throw new MetaEncryptorError('ERR_TOO_MANY_REDIRECTS', {
-    detail: { url, redirectCount: MAX_REDIRECTS }
-  });
+  // Detect when a proxy strips the Range header (200 instead of 206).
+  // Some servers also respond 200 with Content-Range, which is valid.
+  if (resp.status === 200) {
+    const contentRange = resp.headers.get('Content-Range');
+    if (!contentRange) {
+      const cl = parseInt(resp.headers.get('Content-Length') || '0', 10);
+      if (cl === 0 || cl > expectedLen * 2) {
+        throw new MetaEncryptorError('ERR_RANGE_NOT_HONORED', {
+          detail: {
+            rangeHeader,
+            expectedStatus: 206,
+            actualStatus: resp.status,
+            contentLength: cl,
+            expectedLength: expectedLen,
+          }
+        });
+      }
+    }
+  }
+
+  return { response: resp, finalUrl: resolvedFetchUrl(resp, url) };
 }


### PR DESCRIPTION
## 概述

- 修复 v5.0.1 在 CDN **跨域 302 重定向**场景下下载失败的问题，报错为 `ERR_CANNOT_READ_TAIL`，HTTP 状态码为 **0**（例如 `cdn1.dianshudata.com` → `cs-test.dianshudata.com`）。
- v5.0.1 在 `fetchRange` 中使用 `redirect: 'manual'`，意图在重定向时重新携带 `Range` 头（Safari 兼容）。但跨域 302 时浏览器返回 **opaque redirect**（`status === 0`），JS 无法读取 `Location`，手动跟跳失效。
- **修复思路：** 先用 `HEAD` + `redirect: 'follow'` 跟完重定向，取 `response.url` 作为真实文件地址，再对该地址直接发 `Range`（Range 请求不再经过重定向）。Chrome/Firefox 可恢复正常，Safari 也不会在跟跳时丢失 `Range`。

## 改动

- `fetchRange.js`：移除 manual 重定向循环，改回 `redirect: 'follow'`；新增 `resolvedFetchUrl()`
- `downloadUnsealed.js` / `HttpSealedFileStream.js`：用 `headResp.url` 作为后续 Range 请求 URL
- 版本号升至 **5.0.2**

## 测试

- [x] 本地复现 `cdn1.dianshudata.com/…sealed`：v5.0.1 报 HTTP 0，本分支下载成功
- [x] `npm run build` 通过
- [ ] 确认 Safari 在 CDN 跨域重定向场景下仍可正常下载
- [ ] 发布 `5.0.2` 后更新宿主项目（`dianshu-website`、SSR）