### PR TITLE
Feat/download ready transformer 5.0.4

### DIFF
--- a/jest.config.browser.mjs
+++ b/jest.config.browser.mjs
@@ -4,7 +4,8 @@ export default {
   testMatch: [
     "<rootDir>/test/Browser*.spec.mjs",
     "<rootDir>/test/Http*.spec.mjs",
-    "<rootDir>/test/downloadFunctions.spec.mjs"
+    "<rootDir>/test/downloadFunctions.spec.mjs",
+    "<rootDir>/test/progress.spec.mjs"
   ],
   
   roots: ['<rootDir>/test', '<rootDir>/src'],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@yeez-tech/meta-encryptor",
-    "version": "5.0.3",
+    "version": "5.0.4",
     "description": "Data Seal/Unseal for Fidelius",
     "main": "build/commonjs/index.node.cjs",
     "module": "build/es/index.node.js",

--- a/src/browser/HttpSealedFileStream.js
+++ b/src/browser/HttpSealedFileStream.js
@@ -23,9 +23,8 @@ export class HttpSealedFileStream extends ReadableStream {
    * @param {object} [options]
    * @param {number} [options.chunkSize] - bytes per Range request (default 1 MB)
    * @param {Function} [options.fetch] - fetch impl (defaults to globalThis.fetch)
-   * @param {Function} [options.onReady] - called after HEAD+tail validated, before body Range fetches
    */
-  constructor(url, { chunkSize = DEFAULT_CHUNK, fetch: fetchFn, onReady } = {}) {
+  constructor(url, { chunkSize = DEFAULT_CHUNK, fetch: fetchFn } = {}) {
     const _fetch = fetchFn || fetch.bind(globalThis);
     const state = {
       url,
@@ -83,15 +82,6 @@ export class HttpSealedFileStream extends ReadableStream {
         if (state.contentSize <= 0) {
           controller.error(new MetaEncryptorError('ERR_EMPTY_CONTENT'));
           return;
-        }
-
-        if (onReady) {
-          try {
-            onReady();
-          } catch (e) {
-            controller.error(e);
-            return;
-          }
         }
 
         let pos = 0;

--- a/src/browser/HttpSealedFileStream.js
+++ b/src/browser/HttpSealedFileStream.js
@@ -23,8 +23,9 @@ export class HttpSealedFileStream extends ReadableStream {
    * @param {object} [options]
    * @param {number} [options.chunkSize] - bytes per Range request (default 1 MB)
    * @param {Function} [options.fetch] - fetch impl (defaults to globalThis.fetch)
+   * @param {Function} [options.onReady] - called after HEAD+tail validated, before body Range fetches
    */
-  constructor(url, { chunkSize = DEFAULT_CHUNK, fetch: fetchFn } = {}) {
+  constructor(url, { chunkSize = DEFAULT_CHUNK, fetch: fetchFn, onReady } = {}) {
     const _fetch = fetchFn || fetch.bind(globalThis);
     const state = {
       url,
@@ -82,6 +83,15 @@ export class HttpSealedFileStream extends ReadableStream {
         if (state.contentSize <= 0) {
           controller.error(new MetaEncryptorError('ERR_EMPTY_CONTENT'));
           return;
+        }
+
+        if (onReady) {
+          try {
+            onReady();
+          } catch (e) {
+            controller.error(e);
+            return;
+          }
         }
 
         let pos = 0;

--- a/src/browser/README.md
+++ b/src/browser/README.md
@@ -47,6 +47,7 @@ npm install @yeez-tech/meta-encryptor
 | `filename`   | string   | ✅   | 下载文件名（必需，无默认值）                                 |
 | `onLog`      | function | ❌   | 日志回调 `(message: string) => void`                         |
 | `onProgress` | function | ❌   | 进度回调 `(total, processed, readBytes, writeBytes) => void` |
+| `onDownloadReady` | function | ❌ | 下载就绪回调：HEAD+tail 校验完成、正文 Range 开始前触发，可用于关闭准备蒙层 |
 | `onSuccess`  | function | ❌   | 成功回调 `(data: { filename }) => void`                      |
 | `onError`    | function | ❌   | 错误回调 `(error: Error) => void`                            |
 

--- a/src/browser/README.md
+++ b/src/browser/README.md
@@ -47,7 +47,7 @@ npm install @yeez-tech/meta-encryptor
 | `filename`   | string   | ✅   | 下载文件名（必需，无默认值）                                 |
 | `onLog`      | function | ❌   | 日志回调 `(message: string) => void`                         |
 | `onProgress` | function | ❌   | 进度回调 `(total, processed, readBytes, writeBytes) => void` |
-| `onDownloadReady` | function | ❌ | 下载就绪回调：HEAD+tail 校验完成、正文 Range 开始前触发，可用于关闭准备蒙层 |
+| `onDownloadReady` | function | ❌ | 下载就绪回调：HTTP 流首个数据块进入管道时触发（HEAD+tail 完成后），可用于关闭准备蒙层 |
 | `onSuccess`  | function | ❌   | 成功回调 `(data: { filename }) => void`                      |
 | `onError`    | function | ❌   | 错误回调 `(error: Error) => void`                            |
 

--- a/src/browser/blob_download.js
+++ b/src/browser/blob_download.js
@@ -1,13 +1,14 @@
 import { Unsealer } from './Unsealer.js'
 import { HttpSealedFileStream } from './HttpSealedFileStream.js'
+import { createProgressTransformer } from '../common/progress.js';
 
 /**
  * @param {string} url
  * @param {string} privateKeyHex
  * @param {string} filename
- * @param {{ log?: Function, onProgress?: Function, fetch?: Function }} [opts]
+ * @param {{ log?: Function, onProgress?: Function, fetch?: Function, size?: number }} [opts]
  */
-export async function blobDownloadAndDecrypt(url, privateKeyHex, filename, { log, onProgress, fetch: _fetch } = {}) {
+export async function blobDownloadAndDecrypt(url, privateKeyHex, filename, { log, onProgress, fetch: _fetch, size } = {}) {
   log = log || (() => {})
   try {
     const chunks = []
@@ -22,6 +23,7 @@ export async function blobDownloadAndDecrypt(url, privateKeyHex, filename, { log
 
     await stream
       .pipeThrough(unsealer)
+      .pipeThrough(createProgressTransformer(size, onProgress))
       .pipeTo(new WritableStream({
         write(plain) {
           chunks.push(new Uint8Array(plain))

--- a/src/browser/blob_download.js
+++ b/src/browser/blob_download.js
@@ -6,14 +6,14 @@ import { createProgressTransformer } from '../common/progress.js';
  * @param {string} url
  * @param {string} privateKeyHex
  * @param {string} filename
- * @param {{ log?: Function, onProgress?: Function, fetch?: Function, size?: number }} [opts]
+ * @param {{ log?: Function, onProgress?: Function, fetch?: Function, size?: number, onDownloadReady?: Function }} [opts]
  */
-export async function blobDownloadAndDecrypt(url, privateKeyHex, filename, { log, onProgress, fetch: _fetch, size } = {}) {
+export async function blobDownloadAndDecrypt(url, privateKeyHex, filename, { log, onProgress, fetch: _fetch, size, onDownloadReady } = {}) {
   log = log || (() => {})
   try {
     const chunks = []
 
-    const stream = new HttpSealedFileStream(url, { fetch: _fetch })
+    const stream = new HttpSealedFileStream(url, { fetch: _fetch, onReady: onDownloadReady })
     const unsealer = new Unsealer({
       privateKeyHex: privateKeyHex.trim(),
       progressHandler: (total, processed, readBytes, writeBytes) => {

--- a/src/browser/blob_download.js
+++ b/src/browser/blob_download.js
@@ -1,6 +1,6 @@
 import { Unsealer } from './Unsealer.js'
 import { HttpSealedFileStream } from './HttpSealedFileStream.js'
-import { createProgressTransformer } from '../common/progress.js';
+import { createProgressTransformer, createDownloadReadyTransformer } from '../common/progress.js';
 
 /**
  * @param {string} url
@@ -13,7 +13,7 @@ export async function blobDownloadAndDecrypt(url, privateKeyHex, filename, { log
   try {
     const chunks = []
 
-    const stream = new HttpSealedFileStream(url, { fetch: _fetch, onReady: onDownloadReady })
+    const stream = new HttpSealedFileStream(url, { fetch: _fetch })
     const unsealer = new Unsealer({
       privateKeyHex: privateKeyHex.trim(),
       progressHandler: (total, processed, readBytes, writeBytes) => {
@@ -22,6 +22,7 @@ export async function blobDownloadAndDecrypt(url, privateKeyHex, filename, { log
     })
 
     await stream
+      .pipeThrough(createDownloadReadyTransformer(onDownloadReady))
       .pipeThrough(unsealer)
       .pipeThrough(createProgressTransformer(size, onProgress))
       .pipeTo(new WritableStream({

--- a/src/browser/downloadUnsealed.js
+++ b/src/browser/downloadUnsealed.js
@@ -85,6 +85,7 @@ async function inspectSealed(url, log) {
  * @param {string} options.filename
  * @param {Function} [options.onLog]
  * @param {Function} [options.onProgress] - (total, processed, readBytes, writeBytes) => {}
+ * @param {Function} [options.onDownloadReady] - HEAD+tail 完成、正文 Range 开始前触发（可关蒙层）
  * @param {Function} [options.onSuccess]
  * @param {Function} [options.onError]
  * @returns {Promise<void>}
@@ -95,6 +96,7 @@ export async function downloadUnsealed({
   filename,
   onLog,
   onProgress,
+  onDownloadReady,
   onSuccess,
   onError
 }) {
@@ -128,7 +130,12 @@ export async function downloadUnsealed({
     if (!mobile) {
       try {
         log('Trying stream download...')
-        await streamDownloadAndDecrypt(url, key, filename, { log, onProgress, size: meta.plaintextSize })
+        await streamDownloadAndDecrypt(url, key, filename, {
+          log,
+          onProgress,
+          size: meta.plaintextSize,
+          onDownloadReady,
+        })
         if (onSuccess) onSuccess({ filename })
         return
       } catch (e) {
@@ -137,7 +144,7 @@ export async function downloadUnsealed({
     }
 
     log('Using Blob download...')
-    await blobDownloadAndDecrypt(url, key, filename, { log, onProgress })
+    await blobDownloadAndDecrypt(url, key, filename, { log, onProgress, onDownloadReady })
     if (onSuccess) onSuccess({ filename })
   } catch (error) {
     log('Download failed: ' + error.message)

--- a/src/browser/downloadUnsealed.js
+++ b/src/browser/downloadUnsealed.js
@@ -85,7 +85,7 @@ async function inspectSealed(url, log) {
  * @param {string} options.filename
  * @param {Function} [options.onLog]
  * @param {Function} [options.onProgress] - (total, processed, readBytes, writeBytes) => {}
- * @param {Function} [options.onDownloadReady] - HEAD+tail 完成、正文 Range 开始前触发（可关蒙层）
+ * @param {Function} [options.onDownloadReady] - HTTP 流首个数据块进入管道时触发（可关蒙层）
  * @param {Function} [options.onSuccess]
  * @param {Function} [options.onError]
  * @returns {Promise<void>}

--- a/src/browser/stream_download.js
+++ b/src/browser/stream_download.js
@@ -50,14 +50,14 @@ export async function getBestWritable(filename, { log, size } = {}) {
   return null;
 }
 
-export async function streamDownloadAndDecrypt(url, privateKeyHex, filename, { log, onProgress, writable, size, fetch: _fetch } = {}) {
+export async function streamDownloadAndDecrypt(url, privateKeyHex, filename, { log, onProgress, writable, size, fetch: _fetch, onDownloadReady } = {}) {
   log = log || (() => {})
   try {
     const out = writable || await getBestWritable(filename, { log, size })
     if (!out) throw new MetaEncryptorError('ERR_NO_STREAM_WRITABLE');
     log('Stream download starting...');
 
-    const stream = new HttpSealedFileStream(url, { fetch: _fetch })
+    const stream = new HttpSealedFileStream(url, { fetch: _fetch, onReady: onDownloadReady })
     const unsealer = new Unsealer({
       privateKeyHex: privateKeyHex.trim(),
       progressHandler: (total, processed, readBytes, writeBytes) => {

--- a/src/browser/stream_download.js
+++ b/src/browser/stream_download.js
@@ -1,6 +1,7 @@
 import { Unsealer } from './Unsealer.js'
 import { HttpSealedFileStream } from './HttpSealedFileStream.js'
 import { MetaEncryptorError } from '../common/errors.js';
+import { createProgressTransformer } from '../common/progress.js';
 
 async function ensureStreamSaver(log) {
   if (typeof window === 'undefined') return null;
@@ -26,7 +27,14 @@ async function ensureStreamSaver(log) {
 }
 
 export async function getBestWritable(filename, { log, size } = {}) {
-  /*
+ 
+
+  const ss = await ensureStreamSaver(log);
+  if (ss) {
+    log?.('Using StreamSaver...');
+    return ss.createWriteStream(filename, size !== undefined ? { size } : undefined);
+  }
+   
   if (typeof window !== 'undefined' && window.showSaveFilePicker) {
     try {
       log?.('Using File System Access API...');
@@ -37,13 +45,7 @@ export async function getBestWritable(filename, { log, size } = {}) {
       log?.(`File System Access API unavailable: ${e.message}`);
     }
   }
-  */
-
-  const ss = await ensureStreamSaver(log);
-  if (ss) {
-    log?.('Using StreamSaver...');
-    return ss.createWriteStream(filename, size !== undefined ? { size } : undefined);
-  }
+  
 
   return null;
 }
@@ -65,6 +67,7 @@ export async function streamDownloadAndDecrypt(url, privateKeyHex, filename, { l
 
     await stream
       .pipeThrough(unsealer)
+      .pipeThrough(createProgressTransformer(size, onProgress))
       .pipeTo(out)
 
     log('Download complete');

--- a/src/browser/stream_download.js
+++ b/src/browser/stream_download.js
@@ -1,7 +1,7 @@
 import { Unsealer } from './Unsealer.js'
 import { HttpSealedFileStream } from './HttpSealedFileStream.js'
 import { MetaEncryptorError } from '../common/errors.js';
-import { createProgressTransformer } from '../common/progress.js';
+import { createProgressTransformer, createDownloadReadyTransformer } from '../common/progress.js';
 
 async function ensureStreamSaver(log) {
   if (typeof window === 'undefined') return null;
@@ -57,7 +57,7 @@ export async function streamDownloadAndDecrypt(url, privateKeyHex, filename, { l
     if (!out) throw new MetaEncryptorError('ERR_NO_STREAM_WRITABLE');
     log('Stream download starting...');
 
-    const stream = new HttpSealedFileStream(url, { fetch: _fetch, onReady: onDownloadReady })
+    const stream = new HttpSealedFileStream(url, { fetch: _fetch })
     const unsealer = new Unsealer({
       privateKeyHex: privateKeyHex.trim(),
       progressHandler: (total, processed, readBytes, writeBytes) => {
@@ -66,6 +66,7 @@ export async function streamDownloadAndDecrypt(url, privateKeyHex, filename, { l
     })
 
     await stream
+      .pipeThrough(createDownloadReadyTransformer(onDownloadReady))
       .pipeThrough(unsealer)
       .pipeThrough(createProgressTransformer(size, onProgress))
       .pipeTo(out)

--- a/src/common/progress.js
+++ b/src/common/progress.js
@@ -1,0 +1,20 @@
+/**
+ * Create a TransformStream that reports plaintext download progress.
+ * Accumulates bytes from each chunk and calls onProgress.
+ *
+ * @param {number} plaintextSize - total plaintext size in bytes
+ * @param {Function} onProgress - progress callback (totalSize, receivedBytes)
+ * @returns {TransformStream}
+ */
+export function createProgressTransformer(plaintextSize, onProgress) {
+  let received = 0
+  return new TransformStream({
+    transform(chunk, controller) {
+      received += chunk.length
+      if (onProgress) {
+        onProgress(plaintextSize, received)
+      }
+      controller.enqueue(chunk)
+    }
+  })
+}

--- a/src/common/progress.js
+++ b/src/common/progress.js
@@ -18,3 +18,25 @@ export function createProgressTransformer(plaintextSize, onProgress) {
     }
   })
 }
+
+/**
+ * Create a TransformStream that fires once when the first chunk flows through.
+ * Place after HttpSealedFileStream to signal download stream is ready (e.g. dismiss overlay).
+ *
+ * @param {Function} [onDownloadReady]
+ * @returns {TransformStream}
+ */
+export function createDownloadReadyTransformer(onDownloadReady) {
+  let called = false
+  return new TransformStream({
+    transform(chunk, controller) {
+      if (!called) {
+        called = true
+        if (onDownloadReady) {
+          onDownloadReady()
+        }
+      }
+      controller.enqueue(chunk)
+    }
+  })
+}

--- a/src/common/ypccrypto.common.js
+++ b/src/common/ypccrypto.common.js
@@ -132,14 +132,17 @@ function generateAESKeyFrom(pkey, skey){
   return derived_key;
 }
 
-const eth_hash_prefix = Buffer.from("\\x19Ethereum Signed Message:\\n32");
+const eth_hash_prefix = Buffer.concat([
+  Buffer.from([0x19]),
+  Buffer.from("Ethereum Signed Message:\n32"),
+]);
 
 function signMessage(skey, raw) {
-  let raw_hash = Buffer.from(keccak256(Buffer.from(raw)));
+  let raw_hash = Buffer.from(keccak256(toUint8Array(raw)));
   let msg = new Uint8Array(eth_hash_prefix.length + raw_hash.length)
   msg.set(eth_hash_prefix)
   msg.set(raw_hash, eth_hash_prefix.length)
-  msg = Buffer.from(keccak256(Buffer.from(msg)))
+  msg = Buffer.from(keccak256(toUint8Array(msg)))
 
   const msgBytes = toUint8Array(msg);
   const skeyBytes = toUint8Array(skey);

--- a/test/BrowserCrypto.spec.mjs
+++ b/test/BrowserCrypto.spec.mjs
@@ -1,4 +1,5 @@
 import { BrowserCrypto } from '../src/browser/ypccrypto.browser.js';
+import { eth_hash_prefix } from '../src/common/ypccrypto.common.js';
 import fs from 'fs/promises';
 import path from 'path';
 
@@ -253,6 +254,35 @@ describe('BrowserCrypto compatibility with Node YPCCrypto', () => {
       const sig2 = browserCrypto.signMessage(keyB, testMessage);
       expect(Buffer.from(sig2).toString('hex')).not.toBe(Buffer.from(sig1).toString('hex'));
     });
+  });
+});
+
+describe('signMessage Ethereum prefix regression', () => {
+  test('eth_hash_prefix uses correct Ethereum Signed Message format', () => {
+    expect(eth_hash_prefix.length).toBe(28);
+    expect(eth_hash_prefix[0]).toBe(0x19);
+    expect(Buffer.from(eth_hash_prefix.subarray(1)).toString()).toBe(
+      'Ethereum Signed Message:\n32'
+    );
+  });
+
+  test('generateSignature matches v4.x compatible vector', () => {
+    const skey = Buffer.from(
+      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+      'hex'
+    );
+    const epkey = Buffer.from(
+      '2acc91b839b115519fa43b7a0bcf20f7e83ef983c00e854343025a5a26a08a3e2b1bbb2c178989126d09d7a7def36fd029eafd60bdfe046b12b226877e018d92',
+      'hex'
+    );
+    const ehash = Buffer.from(
+      '30890aacb90c4a6440023df1a51a74050756d04811ce0a47eea86dd47dec320a',
+      'hex'
+    );
+    const sig = BrowserCrypto.generateSignature(skey, epkey, ehash);
+    expect(Buffer.from(sig).toString('hex')).toBe(
+      '568643ef491fb8e32d061783a6ac94aacdf7967b39ef53490121c39d7997e043630af675554b5538db2b2bab96068351842490a1ee7551d13417fd1052e41cf61c'
+    );
   });
 });
 

--- a/test/HttpSealedFileStream.spec.mjs
+++ b/test/HttpSealedFileStream.spec.mjs
@@ -117,6 +117,41 @@ describe('HttpSealedFileStream', () => {
     expect(chunks[0].length).toBe(64);
   });
 
+  test('calls onReady after HEAD+tail, before body Range fetches', async () => {
+    const original = Buffer.alloc(100, 'A');
+    const { diskBuf } = sealBuffer(original);
+    let ready = false;
+    let rangeFetchCount = 0;
+
+    const fetch = async (_url, init = {}) => {
+      if (init.method === 'HEAD') {
+        return {
+          ok: true, status: 200,
+          headers: { get: (n) => n.toLowerCase() === 'content-length' ? String(diskBuf.length) : null }
+        };
+      }
+      if (init.headers?.Range) {
+        rangeFetchCount++;
+      }
+      return createMockFetch(diskBuf)(_url, init);
+    };
+
+    const hsfs = new HttpSealedFileStream('http://x', {
+      chunkSize: 4096,
+      fetch,
+      onReady: () => { ready = true; },
+    });
+
+    const reader = hsfs.getReader();
+    while (true) {
+      const { done } = await reader.read();
+      if (done) break;
+    }
+
+    expect(ready).toBe(true);
+    expect(rangeFetchCount).toBeGreaterThan(0);
+  });
+
   test('streams content in multiple chunks with small chunkSize', async () => {
     const original = Buffer.alloc(10000, 'Z');
     const { diskBuf } = sealBuffer(original);

--- a/test/HttpSealedFileStream.spec.mjs
+++ b/test/HttpSealedFileStream.spec.mjs
@@ -13,6 +13,7 @@ import { HeaderSize, BlockInfoSize } from '../src/common/limits.js';
 import { BrowserCrypto } from '../src/browser/ypccrypto.browser.js';
 import { Unsealer } from '../src/browser/Unsealer.js';
 import { HttpSealedFileStream } from '../src/browser/HttpSealedFileStream.js';
+import { createDownloadReadyTransformer } from '../src/common/progress.js';
 import fs from 'fs';
 import path from 'path';
 import crypto from 'crypto';
@@ -117,30 +118,16 @@ describe('HttpSealedFileStream', () => {
     expect(chunks[0].length).toBe(64);
   });
 
-  test('calls onReady after HEAD+tail, before body Range fetches', async () => {
+  test('createDownloadReadyTransformer fires on first chunk from HttpSealedFileStream', async () => {
     const original = Buffer.alloc(100, 'A');
     const { diskBuf } = sealBuffer(original);
     let ready = false;
-    let rangeFetchCount = 0;
 
-    const fetch = async (_url, init = {}) => {
-      if (init.method === 'HEAD') {
-        return {
-          ok: true, status: 200,
-          headers: { get: (n) => n.toLowerCase() === 'content-length' ? String(diskBuf.length) : null }
-        };
-      }
-      if (init.headers?.Range) {
-        rangeFetchCount++;
-      }
-      return createMockFetch(diskBuf)(_url, init);
-    };
-
+    const fetch = createMockFetch(diskBuf);
     const hsfs = new HttpSealedFileStream('http://x', {
       chunkSize: 4096,
       fetch,
-      onReady: () => { ready = true; },
-    });
+    }).pipeThrough(createDownloadReadyTransformer(() => { ready = true; }));
 
     const reader = hsfs.getReader();
     while (true) {
@@ -149,7 +136,6 @@ describe('HttpSealedFileStream', () => {
     }
 
     expect(ready).toBe(true);
-    expect(rangeFetchCount).toBeGreaterThan(0);
   });
 
   test('streams content in multiple chunks with small chunkSize', async () => {

--- a/test/progress.spec.mjs
+++ b/test/progress.spec.mjs
@@ -1,0 +1,55 @@
+import { createProgressTransformer, createDownloadReadyTransformer } from '../src/common/progress.js';
+
+describe('progress transformers', () => {
+  test('createProgressTransformer reports cumulative bytes', async () => {
+    const calls = [];
+    const { readable, writable } = new TransformStream();
+    const writer = writable.getWriter();
+    writer.write(new Uint8Array(3));
+    writer.write(new Uint8Array(2));
+    writer.close();
+
+    const reader = readable
+      .pipeThrough(createProgressTransformer(10, (total, received) => {
+        calls.push([total, received]);
+      }))
+      .getReader();
+
+    while (!(await reader.read()).done) {}
+
+    expect(calls).toEqual([[10, 3], [10, 5]]);
+  });
+
+  test('createDownloadReadyTransformer fires once on first chunk', async () => {
+    let readyCount = 0;
+    const { readable, writable } = new TransformStream();
+    const writer = writable.getWriter();
+    writer.write(new Uint8Array(64));
+    writer.write(new Uint8Array(8));
+    writer.close();
+
+    const reader = readable
+      .pipeThrough(createDownloadReadyTransformer(() => { readyCount++; }))
+      .getReader();
+
+    await reader.read();
+    expect(readyCount).toBe(1);
+    await reader.read();
+    expect(readyCount).toBe(1);
+  });
+
+  test('createDownloadReadyTransformer no-ops when callback omitted', async () => {
+    const { readable, writable } = new TransformStream();
+    const writer = writable.getWriter();
+    writer.write(new Uint8Array(1));
+    writer.close();
+
+    const reader = readable
+      .pipeThrough(createDownloadReadyTransformer())
+      .getReader();
+
+    const { value, done } = await reader.read();
+    expect(done).toBe(false);
+    expect(value.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- **onDownloadReady 回调**：新增 `createDownloadReadyTransformer`（与 `createProgressTransformer` 同模式），在 `stream_download` / `blob_download` 中通过 `pipeThrough` 接入；HTTP 流首个数据块进入管道时触发，便于前端关闭准备蒙层。**不修改 `HttpSealedFileStream.js`**。
- **signMessage 修复**：修正 `eth_hash_prefix` 构造（`\x19` + `Ethereum Signed Message:\n32`），恢复与 v4.x 兼容的签名；补充回归测试。
- **下载进度增强**：`createProgressTransformer` 统一 `onProgress` 回调。
- **版本**：bump to `5.0.4`。

## 管道结构
