### PR TITLE
Fix/recoverable checkpoint and 5.0.4

### DIFF
--- a/jest.config.browser.mjs
+++ b/jest.config.browser.mjs
@@ -4,7 +4,8 @@ export default {
   testMatch: [
     "<rootDir>/test/Browser*.spec.mjs",
     "<rootDir>/test/Http*.spec.mjs",
-    "<rootDir>/test/downloadFunctions.spec.mjs"
+    "<rootDir>/test/downloadFunctions.spec.mjs",
+    "<rootDir>/test/progress.spec.mjs"
   ],
   
   roots: ['<rootDir>/test', '<rootDir>/src'],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@yeez-tech/meta-encryptor",
-    "version": "5.0.3",
+    "version": "5.0.4",
     "description": "Data Seal/Unseal for Fidelius",
     "main": "build/commonjs/index.node.cjs",
     "module": "build/es/index.node.js",

--- a/src/browser/HttpSealedFileStream.js
+++ b/src/browser/HttpSealedFileStream.js
@@ -23,9 +23,8 @@ export class HttpSealedFileStream extends ReadableStream {
    * @param {object} [options]
    * @param {number} [options.chunkSize] - bytes per Range request (default 1 MB)
    * @param {Function} [options.fetch] - fetch impl (defaults to globalThis.fetch)
-   * @param {Function} [options.onReady] - called after HEAD+tail validated, before body Range fetches
    */
-  constructor(url, { chunkSize = DEFAULT_CHUNK, fetch: fetchFn, onReady } = {}) {
+  constructor(url, { chunkSize = DEFAULT_CHUNK, fetch: fetchFn } = {}) {
     const _fetch = fetchFn || fetch.bind(globalThis);
     const state = {
       url,
@@ -83,15 +82,6 @@ export class HttpSealedFileStream extends ReadableStream {
         if (state.contentSize <= 0) {
           controller.error(new MetaEncryptorError('ERR_EMPTY_CONTENT'));
           return;
-        }
-
-        if (onReady) {
-          try {
-            onReady();
-          } catch (e) {
-            controller.error(e);
-            return;
-          }
         }
 
         let pos = 0;

--- a/src/browser/HttpSealedFileStream.js
+++ b/src/browser/HttpSealedFileStream.js
@@ -23,8 +23,9 @@ export class HttpSealedFileStream extends ReadableStream {
    * @param {object} [options]
    * @param {number} [options.chunkSize] - bytes per Range request (default 1 MB)
    * @param {Function} [options.fetch] - fetch impl (defaults to globalThis.fetch)
+   * @param {Function} [options.onReady] - called after HEAD+tail validated, before body Range fetches
    */
-  constructor(url, { chunkSize = DEFAULT_CHUNK, fetch: fetchFn } = {}) {
+  constructor(url, { chunkSize = DEFAULT_CHUNK, fetch: fetchFn, onReady } = {}) {
     const _fetch = fetchFn || fetch.bind(globalThis);
     const state = {
       url,
@@ -82,6 +83,15 @@ export class HttpSealedFileStream extends ReadableStream {
         if (state.contentSize <= 0) {
           controller.error(new MetaEncryptorError('ERR_EMPTY_CONTENT'));
           return;
+        }
+
+        if (onReady) {
+          try {
+            onReady();
+          } catch (e) {
+            controller.error(e);
+            return;
+          }
         }
 
         let pos = 0;

--- a/src/browser/README.md
+++ b/src/browser/README.md
@@ -47,6 +47,7 @@ npm install @yeez-tech/meta-encryptor
 | `filename`   | string   | ✅   | 下载文件名（必需，无默认值）                                 |
 | `onLog`      | function | ❌   | 日志回调 `(message: string) => void`                         |
 | `onProgress` | function | ❌   | 进度回调 `(total, processed, readBytes, writeBytes) => void` |
+| `onDownloadReady` | function | ❌ | 下载就绪回调：HEAD+tail 校验完成、正文 Range 开始前触发，可用于关闭准备蒙层 |
 | `onSuccess`  | function | ❌   | 成功回调 `(data: { filename }) => void`                      |
 | `onError`    | function | ❌   | 错误回调 `(error: Error) => void`                            |
 

--- a/src/browser/README.md
+++ b/src/browser/README.md
@@ -47,7 +47,7 @@ npm install @yeez-tech/meta-encryptor
 | `filename`   | string   | ✅   | 下载文件名（必需，无默认值）                                 |
 | `onLog`      | function | ❌   | 日志回调 `(message: string) => void`                         |
 | `onProgress` | function | ❌   | 进度回调 `(total, processed, readBytes, writeBytes) => void` |
-| `onDownloadReady` | function | ❌ | 下载就绪回调：HEAD+tail 校验完成、正文 Range 开始前触发，可用于关闭准备蒙层 |
+| `onDownloadReady` | function | ❌ | 下载就绪回调：HTTP 流首个数据块进入管道时触发（HEAD+tail 完成后），可用于关闭准备蒙层 |
 | `onSuccess`  | function | ❌   | 成功回调 `(data: { filename }) => void`                      |
 | `onError`    | function | ❌   | 错误回调 `(error: Error) => void`                            |
 

--- a/src/browser/blob_download.js
+++ b/src/browser/blob_download.js
@@ -6,14 +6,14 @@ import { createProgressTransformer } from '../common/progress.js';
  * @param {string} url
  * @param {string} privateKeyHex
  * @param {string} filename
- * @param {{ log?: Function, onProgress?: Function, fetch?: Function, size?: number }} [opts]
+ * @param {{ log?: Function, onProgress?: Function, fetch?: Function, size?: number, onDownloadReady?: Function }} [opts]
  */
-export async function blobDownloadAndDecrypt(url, privateKeyHex, filename, { log, onProgress, fetch: _fetch, size } = {}) {
+export async function blobDownloadAndDecrypt(url, privateKeyHex, filename, { log, onProgress, fetch: _fetch, size, onDownloadReady } = {}) {
   log = log || (() => {})
   try {
     const chunks = []
 
-    const stream = new HttpSealedFileStream(url, { fetch: _fetch })
+    const stream = new HttpSealedFileStream(url, { fetch: _fetch, onReady: onDownloadReady })
     const unsealer = new Unsealer({
       privateKeyHex: privateKeyHex.trim(),
       progressHandler: (total, processed, readBytes, writeBytes) => {

--- a/src/browser/blob_download.js
+++ b/src/browser/blob_download.js
@@ -1,6 +1,6 @@
 import { Unsealer } from './Unsealer.js'
 import { HttpSealedFileStream } from './HttpSealedFileStream.js'
-import { createProgressTransformer } from '../common/progress.js';
+import { createProgressTransformer, createDownloadReadyTransformer } from '../common/progress.js';
 
 /**
  * @param {string} url
@@ -13,7 +13,7 @@ export async function blobDownloadAndDecrypt(url, privateKeyHex, filename, { log
   try {
     const chunks = []
 
-    const stream = new HttpSealedFileStream(url, { fetch: _fetch, onReady: onDownloadReady })
+    const stream = new HttpSealedFileStream(url, { fetch: _fetch })
     const unsealer = new Unsealer({
       privateKeyHex: privateKeyHex.trim(),
       progressHandler: (total, processed, readBytes, writeBytes) => {
@@ -22,6 +22,7 @@ export async function blobDownloadAndDecrypt(url, privateKeyHex, filename, { log
     })
 
     await stream
+      .pipeThrough(createDownloadReadyTransformer(onDownloadReady))
       .pipeThrough(unsealer)
       .pipeThrough(createProgressTransformer(size, onProgress))
       .pipeTo(new WritableStream({

--- a/src/browser/downloadUnsealed.js
+++ b/src/browser/downloadUnsealed.js
@@ -85,6 +85,7 @@ async function inspectSealed(url, log) {
  * @param {string} options.filename
  * @param {Function} [options.onLog]
  * @param {Function} [options.onProgress] - (total, processed, readBytes, writeBytes) => {}
+ * @param {Function} [options.onDownloadReady] - HEAD+tail 完成、正文 Range 开始前触发（可关蒙层）
  * @param {Function} [options.onSuccess]
  * @param {Function} [options.onError]
  * @returns {Promise<void>}
@@ -95,6 +96,7 @@ export async function downloadUnsealed({
   filename,
   onLog,
   onProgress,
+  onDownloadReady,
   onSuccess,
   onError
 }) {
@@ -128,7 +130,12 @@ export async function downloadUnsealed({
     if (!mobile) {
       try {
         log('Trying stream download...')
-        await streamDownloadAndDecrypt(url, key, filename, { log, onProgress, size: meta.plaintextSize })
+        await streamDownloadAndDecrypt(url, key, filename, {
+          log,
+          onProgress,
+          size: meta.plaintextSize,
+          onDownloadReady,
+        })
         if (onSuccess) onSuccess({ filename })
         return
       } catch (e) {
@@ -137,7 +144,7 @@ export async function downloadUnsealed({
     }
 
     log('Using Blob download...')
-    await blobDownloadAndDecrypt(url, key, filename, { log, onProgress })
+    await blobDownloadAndDecrypt(url, key, filename, { log, onProgress, onDownloadReady })
     if (onSuccess) onSuccess({ filename })
   } catch (error) {
     log('Download failed: ' + error.message)

--- a/src/browser/downloadUnsealed.js
+++ b/src/browser/downloadUnsealed.js
@@ -85,7 +85,7 @@ async function inspectSealed(url, log) {
  * @param {string} options.filename
  * @param {Function} [options.onLog]
  * @param {Function} [options.onProgress] - (total, processed, readBytes, writeBytes) => {}
- * @param {Function} [options.onDownloadReady] - HEAD+tail 完成、正文 Range 开始前触发（可关蒙层）
+ * @param {Function} [options.onDownloadReady] - HTTP 流首个数据块进入管道时触发（可关蒙层）
  * @param {Function} [options.onSuccess]
  * @param {Function} [options.onError]
  * @returns {Promise<void>}

--- a/src/browser/stream_download.js
+++ b/src/browser/stream_download.js
@@ -50,14 +50,14 @@ export async function getBestWritable(filename, { log, size } = {}) {
   return null;
 }
 
-export async function streamDownloadAndDecrypt(url, privateKeyHex, filename, { log, onProgress, writable, size, fetch: _fetch } = {}) {
+export async function streamDownloadAndDecrypt(url, privateKeyHex, filename, { log, onProgress, writable, size, fetch: _fetch, onDownloadReady } = {}) {
   log = log || (() => {})
   try {
     const out = writable || await getBestWritable(filename, { log, size })
     if (!out) throw new MetaEncryptorError('ERR_NO_STREAM_WRITABLE');
     log('Stream download starting...');
 
-    const stream = new HttpSealedFileStream(url, { fetch: _fetch })
+    const stream = new HttpSealedFileStream(url, { fetch: _fetch, onReady: onDownloadReady })
     const unsealer = new Unsealer({
       privateKeyHex: privateKeyHex.trim(),
       progressHandler: (total, processed, readBytes, writeBytes) => {

--- a/src/browser/stream_download.js
+++ b/src/browser/stream_download.js
@@ -1,7 +1,7 @@
 import { Unsealer } from './Unsealer.js'
 import { HttpSealedFileStream } from './HttpSealedFileStream.js'
 import { MetaEncryptorError } from '../common/errors.js';
-import { createProgressTransformer } from '../common/progress.js';
+import { createProgressTransformer, createDownloadReadyTransformer } from '../common/progress.js';
 
 async function ensureStreamSaver(log) {
   if (typeof window === 'undefined') return null;
@@ -57,7 +57,7 @@ export async function streamDownloadAndDecrypt(url, privateKeyHex, filename, { l
     if (!out) throw new MetaEncryptorError('ERR_NO_STREAM_WRITABLE');
     log('Stream download starting...');
 
-    const stream = new HttpSealedFileStream(url, { fetch: _fetch, onReady: onDownloadReady })
+    const stream = new HttpSealedFileStream(url, { fetch: _fetch })
     const unsealer = new Unsealer({
       privateKeyHex: privateKeyHex.trim(),
       progressHandler: (total, processed, readBytes, writeBytes) => {
@@ -66,6 +66,7 @@ export async function streamDownloadAndDecrypt(url, privateKeyHex, filename, { l
     })
 
     await stream
+      .pipeThrough(createDownloadReadyTransformer(onDownloadReady))
       .pipeThrough(unsealer)
       .pipeThrough(createProgressTransformer(size, onProgress))
       .pipeTo(out)

--- a/src/common/progress.js
+++ b/src/common/progress.js
@@ -18,3 +18,25 @@ export function createProgressTransformer(plaintextSize, onProgress) {
     }
   })
 }
+
+/**
+ * Create a TransformStream that fires once when the first chunk flows through.
+ * Place after HttpSealedFileStream to signal download stream is ready (e.g. dismiss overlay).
+ *
+ * @param {Function} [onDownloadReady]
+ * @returns {TransformStream}
+ */
+export function createDownloadReadyTransformer(onDownloadReady) {
+  let called = false
+  return new TransformStream({
+    transform(chunk, controller) {
+      if (!called) {
+        called = true
+        if (onDownloadReady) {
+          onDownloadReady()
+        }
+      }
+      controller.enqueue(chunk)
+    }
+  })
+}

--- a/src/common/ypccrypto.common.js
+++ b/src/common/ypccrypto.common.js
@@ -132,14 +132,17 @@ function generateAESKeyFrom(pkey, skey){
   return derived_key;
 }
 
-const eth_hash_prefix = Buffer.from("\\x19Ethereum Signed Message:\\n32");
+const eth_hash_prefix = Buffer.concat([
+  Buffer.from([0x19]),
+  Buffer.from("Ethereum Signed Message:\n32"),
+]);
 
 function signMessage(skey, raw) {
-  let raw_hash = Buffer.from(keccak256(Buffer.from(raw)));
+  let raw_hash = Buffer.from(keccak256(toUint8Array(raw)));
   let msg = new Uint8Array(eth_hash_prefix.length + raw_hash.length)
   msg.set(eth_hash_prefix)
   msg.set(raw_hash, eth_hash_prefix.length)
-  msg = Buffer.from(keccak256(Buffer.from(msg)))
+  msg = Buffer.from(keccak256(toUint8Array(msg)))
 
   const msgBytes = toUint8Array(msg);
   const skeyBytes = toUint8Array(skey);

--- a/src/node/PipelineConext.js
+++ b/src/node/PipelineConext.js
@@ -5,9 +5,21 @@ import { promisify } from 'util';
 
 import { MetaEncryptorError } from '../common/errors.js';
 
-const readFile = promisify(fs.readFile);
-const writeFile = promisify(fs.writeFile);
+const open = promisify(fs.open);
+const close = promisify(fs.close);
+const fsync = promisify(fs.fsync);
+const rename = promisify(fs.rename);
 const logger = log.getLogger("meta-encryptor/PipelineContext");
+
+function toBinaryChunk(value) {
+    if (Buffer.isBuffer(value)) {
+        return value;
+    }
+    if (value instanceof Uint8Array) {
+        return Buffer.from(value.buffer, value.byteOffset, value.byteLength);
+    }
+    return null;
+}
 
 export class PipelineContext {
     constructor(options) {
@@ -37,25 +49,25 @@ export class PipelineContextInFile extends PipelineContext {
     constructor(filePath, options) {
         super(options);
         this.filePath = filePath;
+        this._saveTail = Promise.resolve();
+        this._saveDirty = false;
     }
 
-    async saveContext() {
+    _buildPayload() {
         const binaryChunks = [];
         const meta = {};
         let offset = 0;
 
-        logger.debug("Context before save:", this.context);
-        logger.debug("PipelineContextInFile::saveContext saving to ", this.filePath);
-
         for (const [key, value] of Object.entries(this.context)) {
-            if (Buffer.isBuffer(value)) {
-                binaryChunks.push(value);
+            const binary = toBinaryChunk(value);
+            if (binary) {
+                binaryChunks.push(binary);
                 meta[key] = {
                     type: 'binary',
                     offset,
-                    length: value.length
+                    length: binary.length
                 };
-                offset += value.length;
+                offset += binary.length;
             } else {
                 meta[key] = {
                     type: 'json',
@@ -68,26 +80,58 @@ export class PipelineContextInFile extends PipelineContext {
         const metaBuffer = Buffer.from(metaStr);
         const metaLength = metaBuffer.length;
 
-        try {
-            const fd = await promisify(fs.open)(this.filePath, 'w');
-            const lengthBuffer = Buffer.alloc(4);
-            lengthBuffer.writeUInt32BE(metaLength);
-            await promisify(fs.write)(fd, lengthBuffer, 0, 4, 0);
-            await promisify(fs.write)(fd, metaBuffer, 0, metaLength, 4);
-            let currentOffset = 4 + metaLength;
-            for (const chunk of binaryChunks) {
-                await promisify(fs.write)(fd, chunk, 0, chunk.length, currentOffset);
-                currentOffset += chunk.length;
-            }
-            await promisify(fs.close)(fd);
-        } catch (error) {
-            logger.error('PipelineContextInFile::saveContext error:', error.message);
-            throw error;
+        const totalSize = 4 + metaLength + offset;
+        const fileBuffer = Buffer.alloc(totalSize);
+        fileBuffer.writeUInt32BE(metaLength, 0);
+        metaBuffer.copy(fileBuffer, 4);
+        let currentOffset = 4 + metaLength;
+        for (const chunk of binaryChunks) {
+            chunk.copy(fileBuffer, currentOffset);
+            currentOffset += chunk.length;
         }
+
+        return fileBuffer;
+    }
+
+    async _writeContextAtomic() {
+        const fileBuffer = this._buildPayload();
+        const tmpPath = `${this.filePath}.tmp`;
+
+        logger.debug("PipelineContextInFile::saveContext saving to ", this.filePath);
+
+        const fd = await open(tmpPath, 'w');
+        try {
+            await promisify(fs.write)(fd, fileBuffer, 0, fileBuffer.length, 0);
+            await fsync(fd);
+        } finally {
+            await close(fd);
+        }
+
+        await rename(tmpPath, this.filePath);
+    }
+
+    async _flushAll() {
+        while (this._saveDirty) {
+            this._saveDirty = false;
+            try {
+                await this._writeContextAtomic();
+            } catch (error) {
+                logger.error('PipelineContextInFile::saveContext error:', error.message);
+                throw error;
+            }
+        }
+    }
+
+    saveContext() {
+        this._saveDirty = true;
+        this._saveTail = this._saveTail.then(() => this._flushAll());
+        return this._saveTail;
     }
 
     async loadContext() {
         try {
+            await this._saveTail;
+
             if (!fs.existsSync(this.filePath)) {
                 this.context = {};
                 this.runtime.rawCommitted = 0;
@@ -96,7 +140,7 @@ export class PipelineContextInFile extends PipelineContext {
                 return;
             }
 
-            const fd = await promisify(fs.open)(this.filePath, 'r');
+            const fd = await open(this.filePath, 'r');
             const metaLengthBuffer = Buffer.alloc(4);
             await promisify(fs.read)(fd, metaLengthBuffer, 0, 4, 0);
             const metaLength = metaLengthBuffer.readUInt32BE();
@@ -118,7 +162,7 @@ export class PipelineContextInFile extends PipelineContext {
                 }
             }
 
-            await promisify(fs.close)(fd);
+            await close(fd);
 
             const readStart = this.context.readStart || 0;
             const writeStart = this.context.writeStart || 0;

--- a/src/node/Recoverable.js
+++ b/src/node/Recoverable.js
@@ -219,7 +219,7 @@ export class RecoverableWriteStream extends Writable {
         const blocks = runtime.pendingBlocks || [];
 
         let hasCommittedBlock = false;
-        let committedRawBytes = 0;
+        let committedItems = 0;
 
         logger.debug("On plaintext written:", writtenBytes, " bytes. Current runtime:", runtime);
         while(remain > 0 && blocks.length > 0){
@@ -233,9 +233,9 @@ export class RecoverableWriteStream extends Writable {
                 // Block fully committed
                 runtime.rawCommitted += block.rawSize;
                 runtime.plainCommitted += block.plainSize;
-                committedRawBytes += block.rawSize;
                 blocks.shift();
                 hasCommittedBlock = true;
+                committedItems += 1;
             }
         }
         logger.debug("After committing, remaining to commit:", remain, " bytes. Updated runtime:", runtime);
@@ -244,31 +244,33 @@ export class RecoverableWriteStream extends Writable {
             return Promise.resolve();
         }
         if(this.context.context){
-            const buf = this.context.context['data'];
-            if(Buffer.isBuffer(buf) && buf.length > 0 &&
-               committedRawBytes > 0){
-                if(committedRawBytes >= buf.length){
-                    // All data committed
-                    this.context.context['data'] = Buffer.alloc(0);
-                }else{
-                    // Partial data committed
-                    this.context.context['data'] = buf.subarray(committedRawBytes);
-                }
-            }
             this.context.context['readStart'] = runtime.rawCommitted;
             this.context.context['writeStart'] = runtime.plainCommitted;
+            if (committedItems > 0) {
+                this.context.context['readItemCount'] =
+                    (this.context.context['readItemCount'] || 0) + committedItems;
+            }
+            // Checkpoint only fully committed progress; discard in-flight cipher tail.
+            this.context.context['data'] = Buffer.alloc(0);
             logger.debug("After writing, updated readStart to:", this.context.context['readStart'],
                          " writeStart to:", this.context.context['writeStart'],
-                         " data length to:", this.context.context['data'] ? this.context.context['data'].length : 0);
-            //
-            this.context.saveContext();
+                         " readItemCount to:", this.context.context['readItemCount']);
+            return this.context.saveContext();
         }
         return Promise.resolve();
     }
 
     _final(callback) {
         this.writeStream.on('finish', () => {
-            const writeStart = this.context.context['writeStart'] || 0;
+            const ctx = this.context && this.context.context;
+            const runtime = this.context && this.context.runtime;
+            const writeStart = (ctx && ctx['writeStart']) || (runtime && runtime.plainCommitted) || 0;
+
+            if (ctx && runtime) {
+                ctx['readStart'] = runtime.rawCommitted;
+                ctx['writeStart'] = runtime.plainCommitted;
+                ctx['data'] = Buffer.alloc(0);
+            }
 
             // Always truncate to writeStart to remove any residual
             // data from previous incomplete write attempts.
@@ -276,8 +278,14 @@ export class RecoverableWriteStream extends Writable {
                 if (truncateErr) {
                     logger.warn("Error truncating file:", truncateErr);
                     callback(truncateErr);
+                    return;
+                }
+                logger.debug("File truncated successfully to length:", writeStart);
+                if (this.context && typeof this.context.saveContext === 'function') {
+                    Promise.resolve(this.context.saveContext())
+                        .then(() => callback())
+                        .catch((err) => callback(err));
                 } else {
-                    logger.debug("File truncated successfully to length:", writeStart);
                     callback();
                 }
             });

--- a/src/node/Unsealer.js
+++ b/src/node/Unsealer.js
@@ -18,6 +18,7 @@ export class Unsealer extends Transform {
     const keyPair = options.keyPair;
     const progressHandler = options.progressHandler;
     const context = options ? options.context : undefined;
+    const ctx = context && context.context ? context.context : {};
 
     // Node-specific rolling keccak256 hash
     let dataHash = Buffer.from(keccak256(Buffer.from("Fidelius", "utf-8")));
@@ -55,9 +56,9 @@ export class Unsealer extends Transform {
         }
       },
       initialState: {
-        readItemCount: options ? (options.processedItemCount || 0) : 0,
-        processedBytes: options ? (options.processedBytes || 0) : 0,
-        writeBytes: options ? (options.writeBytes || 0) : 0,
+        readItemCount: options?.processedItemCount ?? ctx.readItemCount ?? 0,
+        processedBytes: options?.processedBytes ?? ctx.readStart ?? 0,
+        writeBytes: options?.writeBytes ?? ctx.writeStart ?? 0,
       }
     });
 
@@ -81,7 +82,10 @@ export class Unsealer extends Transform {
 
       // persist trailing unconsumed bytes for recoverable stream context
       if (this._context && this._context.context && this._context.context["status"] === "file") {
-        this._context.context["data"] = this.#core.remaining;
+        const remaining = this.#core.remaining;
+        this._context.context["data"] = remaining.length > 0
+          ? Buffer.from(remaining.buffer, remaining.byteOffset, remaining.byteLength)
+          : Buffer.alloc(0);
       }
 
       callback();

--- a/test/BrowserCrypto.spec.mjs
+++ b/test/BrowserCrypto.spec.mjs
@@ -1,4 +1,5 @@
 import { BrowserCrypto } from '../src/browser/ypccrypto.browser.js';
+import { eth_hash_prefix } from '../src/common/ypccrypto.common.js';
 import fs from 'fs/promises';
 import path from 'path';
 
@@ -253,6 +254,35 @@ describe('BrowserCrypto compatibility with Node YPCCrypto', () => {
       const sig2 = browserCrypto.signMessage(keyB, testMessage);
       expect(Buffer.from(sig2).toString('hex')).not.toBe(Buffer.from(sig1).toString('hex'));
     });
+  });
+});
+
+describe('signMessage Ethereum prefix regression', () => {
+  test('eth_hash_prefix uses correct Ethereum Signed Message format', () => {
+    expect(eth_hash_prefix.length).toBe(28);
+    expect(eth_hash_prefix[0]).toBe(0x19);
+    expect(Buffer.from(eth_hash_prefix.subarray(1)).toString()).toBe(
+      'Ethereum Signed Message:\n32'
+    );
+  });
+
+  test('generateSignature matches v4.x compatible vector', () => {
+    const skey = Buffer.from(
+      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+      'hex'
+    );
+    const epkey = Buffer.from(
+      '2acc91b839b115519fa43b7a0bcf20f7e83ef983c00e854343025a5a26a08a3e2b1bbb2c178989126d09d7a7def36fd029eafd60bdfe046b12b226877e018d92',
+      'hex'
+    );
+    const ehash = Buffer.from(
+      '30890aacb90c4a6440023df1a51a74050756d04811ce0a47eea86dd47dec320a',
+      'hex'
+    );
+    const sig = BrowserCrypto.generateSignature(skey, epkey, ehash);
+    expect(Buffer.from(sig).toString('hex')).toBe(
+      '568643ef491fb8e32d061783a6ac94aacdf7967b39ef53490121c39d7997e043630af675554b5538db2b2bab96068351842490a1ee7551d13417fd1052e41cf61c'
+    );
   });
 });
 

--- a/test/HttpSealedFileStream.spec.mjs
+++ b/test/HttpSealedFileStream.spec.mjs
@@ -117,6 +117,41 @@ describe('HttpSealedFileStream', () => {
     expect(chunks[0].length).toBe(64);
   });
 
+  test('calls onReady after HEAD+tail, before body Range fetches', async () => {
+    const original = Buffer.alloc(100, 'A');
+    const { diskBuf } = sealBuffer(original);
+    let ready = false;
+    let rangeFetchCount = 0;
+
+    const fetch = async (_url, init = {}) => {
+      if (init.method === 'HEAD') {
+        return {
+          ok: true, status: 200,
+          headers: { get: (n) => n.toLowerCase() === 'content-length' ? String(diskBuf.length) : null }
+        };
+      }
+      if (init.headers?.Range) {
+        rangeFetchCount++;
+      }
+      return createMockFetch(diskBuf)(_url, init);
+    };
+
+    const hsfs = new HttpSealedFileStream('http://x', {
+      chunkSize: 4096,
+      fetch,
+      onReady: () => { ready = true; },
+    });
+
+    const reader = hsfs.getReader();
+    while (true) {
+      const { done } = await reader.read();
+      if (done) break;
+    }
+
+    expect(ready).toBe(true);
+    expect(rangeFetchCount).toBeGreaterThan(0);
+  });
+
   test('streams content in multiple chunks with small chunkSize', async () => {
     const original = Buffer.alloc(10000, 'Z');
     const { diskBuf } = sealBuffer(original);

--- a/test/HttpSealedFileStream.spec.mjs
+++ b/test/HttpSealedFileStream.spec.mjs
@@ -13,6 +13,7 @@ import { HeaderSize, BlockInfoSize } from '../src/common/limits.js';
 import { BrowserCrypto } from '../src/browser/ypccrypto.browser.js';
 import { Unsealer } from '../src/browser/Unsealer.js';
 import { HttpSealedFileStream } from '../src/browser/HttpSealedFileStream.js';
+import { createDownloadReadyTransformer } from '../src/common/progress.js';
 import fs from 'fs';
 import path from 'path';
 import crypto from 'crypto';
@@ -117,30 +118,16 @@ describe('HttpSealedFileStream', () => {
     expect(chunks[0].length).toBe(64);
   });
 
-  test('calls onReady after HEAD+tail, before body Range fetches', async () => {
+  test('createDownloadReadyTransformer fires on first chunk from HttpSealedFileStream', async () => {
     const original = Buffer.alloc(100, 'A');
     const { diskBuf } = sealBuffer(original);
     let ready = false;
-    let rangeFetchCount = 0;
 
-    const fetch = async (_url, init = {}) => {
-      if (init.method === 'HEAD') {
-        return {
-          ok: true, status: 200,
-          headers: { get: (n) => n.toLowerCase() === 'content-length' ? String(diskBuf.length) : null }
-        };
-      }
-      if (init.headers?.Range) {
-        rangeFetchCount++;
-      }
-      return createMockFetch(diskBuf)(_url, init);
-    };
-
+    const fetch = createMockFetch(diskBuf);
     const hsfs = new HttpSealedFileStream('http://x', {
       chunkSize: 4096,
       fetch,
-      onReady: () => { ready = true; },
-    });
+    }).pipeThrough(createDownloadReadyTransformer(() => { ready = true; }));
 
     const reader = hsfs.getReader();
     while (true) {
@@ -149,7 +136,6 @@ describe('HttpSealedFileStream', () => {
     }
 
     expect(ready).toBe(true);
-    expect(rangeFetchCount).toBeGreaterThan(0);
   });
 
   test('streams content in multiple chunks with small chunkSize', async () => {

--- a/test/progress.spec.mjs
+++ b/test/progress.spec.mjs
@@ -1,0 +1,55 @@
+import { createProgressTransformer, createDownloadReadyTransformer } from '../src/common/progress.js';
+
+describe('progress transformers', () => {
+  test('createProgressTransformer reports cumulative bytes', async () => {
+    const calls = [];
+    const { readable, writable } = new TransformStream();
+    const writer = writable.getWriter();
+    writer.write(new Uint8Array(3));
+    writer.write(new Uint8Array(2));
+    writer.close();
+
+    const reader = readable
+      .pipeThrough(createProgressTransformer(10, (total, received) => {
+        calls.push([total, received]);
+      }))
+      .getReader();
+
+    while (!(await reader.read()).done) {}
+
+    expect(calls).toEqual([[10, 3], [10, 5]]);
+  });
+
+  test('createDownloadReadyTransformer fires once on first chunk', async () => {
+    let readyCount = 0;
+    const { readable, writable } = new TransformStream();
+    const writer = writable.getWriter();
+    writer.write(new Uint8Array(64));
+    writer.write(new Uint8Array(8));
+    writer.close();
+
+    const reader = readable
+      .pipeThrough(createDownloadReadyTransformer(() => { readyCount++; }))
+      .getReader();
+
+    await reader.read();
+    expect(readyCount).toBe(1);
+    await reader.read();
+    expect(readyCount).toBe(1);
+  });
+
+  test('createDownloadReadyTransformer no-ops when callback omitted', async () => {
+    const { readable, writable } = new TransformStream();
+    const writer = writable.getWriter();
+    writer.write(new Uint8Array(1));
+    writer.close();
+
+    const reader = readable
+      .pipeThrough(createDownloadReadyTransformer())
+      .getReader();
+
+    const { value, done } = await reader.read();
+    expect(done).toBe(false);
+    expect(value.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

本 PR 在 `develop`（已合入 #20 测试改动）基础上，补齐 **Node Recoverable 库侧修复**，并 **同步 `main` 5.0.4** 浏览器更新。

---

### 一、Node — Recoverable 断点续传修复

#### 背景

#20 已将 pause/resume 测试改为 README 标准用法（不手动 `saveContext`），但库侧存在：

1. `saveContext()` 原地 `open('w')` 覆盖 + fire-and-forget，多次并发写同一文件 → `context.dat` meta JSON 损坏（multipause 在 `loadContext` 报 `Bad control character`）
2. `Unsealer` 把 `remaining` 写成 `Uint8Array`，`saveContext` 只认 `Buffer` → 密文尾巴被 `JSON.stringify` 塞进 meta（体积膨胀、写盘更慢）
3. `readItemCount` 未持久化 / resume 未从 context 恢复 → 续传密文错位（`Public Key could not be parsed`）
4. Write 侧对 `data` 的错误 `subarray` 与 Unsealer `remaining` 语义不一致

设计要求：**不依赖宿主或 pause 回调调 `saveContext`**，pause 与断电走同一套自动落盘路径。

#### `PipelineContextInFile` — 落盘可靠性

| 改动 | 说明 |
|------|------|
| **原子写（临时文件）** | 内存拼好 payload → 写 `context.dat.tmp` → `fsync` → `rename` 替换正式文件；写盘中断时旧 `context.dat` 仍完整可读 |
| **不再原地覆盖** | 避免并发/重叠 save 互相 `truncate` 把 meta 写花 |
| **save 合并排队** | `_saveDirty` + `_saveTail`：流式解密中多次触发 save，合并为少量完整写入 |
| **`loadContext` 等待 pending save** | `await _saveTail` 后再读盘，避免 stage 结束立刻 load 读到半成品 |
| **`Uint8Array` → binary 区** | `Buffer` / `Uint8Array` 均进 binary 段，不再误进 JSON |

> **文件格式未变**：仍是 `[4B meta 长度][meta JSON][binary 区]`。`readStart` / `writeStart` / `readItemCount` 等指针仍在 meta JSON 里；仅写盘策略从「原地覆盖」改为「临时文件 + 原子替换」。

#### `RecoverableWriteStream` — 自动检查点

- **item 整块明文提交后**：更新 `readStart` / `writeStart` / `readItemCount` 并 `saveContext()`
- **`ws.end()` / `_final`**：truncate 明文到 `writeStart` 后再 save（与 pause、异常退出路径一致）
- **检查点语义**：只持久化**已提交**进度；半 item 的 `data` 清空，resume 从上一 item 边界重解（与断电回退一致）
- **移除** Write 侧对 `data` 的错误 `subarray`

#### `Unsealer` — resume 自恢复

- 构造时从 `context.context` 读取 `readItemCount` / `readStart` / `writeStart`（宿主不必再传 `processedItemCount`）
- `data` 统一写成 `Buffer`

#### 与 #20 测试的关系

- #20 提供标准 pause/resume + 浏览器 callback 测试
- 本 PR 提供库侧修复，使以下用例**无需 pause 内手动 save** 即可通过：
  - `test pipeline context with pause and resume from large file`
  - `test pipeline context with multiple random pause and resume`

---

### 二、同步 main — 5.0.4（PR #18）

| 改动 | 说明 |
|------|------|
| **`onDownloadReady`** | 浏览器下载 HEAD+tail 完成后、首个数据块进管道时回调（关 loading 蒙层） |
| **`createDownloadReadyTransformer`** | ready 信号独立 TransformStream，与 progress transformer 同模式 |
| **`signMessage` 前缀修复** | `ypccrypto.common.js` 修正 Ethereum 前缀，恢复 v4.x 兼容签名 |
| **版本号** | `5.0.3` → `5.0.4` |
| **测试** | 新增 `test/progress.spec.mjs`；`jest.config.browser.mjs` 注册 |

---

## 变更文件（相对 develop）

- `src/node/PipelineConext.js` — 原子落盘、save 排队、Uint8Array binary
- `src/node/Recoverable.js` — 自动检查点、readItemCount 持久化
- `src/node/Unsealer.js` — resume 从 context 恢复
- `src/browser/*`、`src/common/progress.js`、`src/common/ypccrypto.common.js` — 5.0.4
- `package.json`、`jest.config.browser.mjs`、相关测试

---

## Test plan

- [ ] `npm run test:node -- test/Recoverable.spec.js -t "^test pipeline context with pause and resume from large file$"`
- [ ] `npm run test:node -- test/Recoverable.spec.js -t "^test pipeline context with multiple random pause and resume$"`
- [ ] `npm run test:node -- test/Recoverable.spec.js --forceExit`
- [ ] `npm run test:node -- test/PipelineContext.spec.js`
- [ ] `npm run test:browser`（含 `progress` / `downloadCallbacks` / `downloadUnsealedCallbacks`）
- [ ] `npm run test:node -- test/BrowserCrypto.spec.mjs`（signMessage 回归）